### PR TITLE
Add cloud-config examples for AWS and Azure

### DIFF
--- a/bin/aws.sh
+++ b/bin/aws.sh
@@ -7,10 +7,10 @@ fi
 
 # Name of the instance to be created
 NAME=ks-dev
-# Name of the SSJ key pair to use. This key pair must already exist in the AWS account.
+# Name of the SSH key pair to use. This key pair must already exist in the AWS account.
 KEY=ks-galaxy-aws
 
-DISK=300
+DISK_SIZE_GB=300
 # Security group to use. This security group must already exist in the AWS
 # account and allow incoming traffic on ports 22, 80, and 6443.
 GROUP=ks-dev-sg
@@ -48,7 +48,7 @@ mapping=$(cat << EOF
   {
     "DeviceName": "/dev/sdb",
     "Ebs": {
-      "VolumeSize": $DISK,
+      "VolumeSize": $DISK_SIZE_GB,
       "VolumeType": "gp3"
     }
   }
@@ -85,7 +85,7 @@ case $command in
     aws ec2 terminate-instances --instance-ids $ID
     ;;
   *)
-    echo 'Usage: bin/azure.sh start|stop'
+    echo 'Usage: bin/aws.sh start|stop'
     exit 1
     ;;
 esac

--- a/bin/aws.sh
+++ b/bin/aws.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+if [[ $# -eq 0 ]] ; then
+  echo 'Usage: bin/aws.sh start|stop'
+  exit 1
+fi
+
+# Name of the instance to be created
+NAME=ks-dev
+# Name of the SSJ key pair to use. This key pair must already exist in the AWS account.
+KEY=ks-galaxy-aws
+
+DISK=300
+# Security group to use. This security group must already exist in the AWS
+# account and allow incoming traffic on ports 22, 80, and 6443.
+GROUP=ks-dev-sg
+IMAGE=ami-0e2c8caa4b6378d8c
+TYPE=m6i.4xlarge
+
+DIR=$(dirname $(realpath $0))
+
+command=$1
+shift
+while [[ $# > 0 ]]; do
+  case $1 in
+    -n|--name) NAME=$2 ; shift ;;
+    -k|--key) KEY=$2 ; shift ;;
+    -g|--group) GROUP=$2 ; shift ;;
+    -i|--image) IMAGE=$2 ; shift ;;
+    -t|--type) SIZE=$2 ; shift ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+mapping=$(cat << EOF
+[
+  {
+    "DeviceName": "/dev/sda1",
+    "Ebs": {
+      "VolumeSize": 30,
+      "VolumeType": "gp3"
+    }
+  },
+  {
+    "DeviceName": "/dev/sdb",
+    "Ebs": {
+      "VolumeSize": $DISK,
+      "VolumeType": "gp3"
+    }
+  }
+]
+EOF
+)
+
+case $command in
+  start)
+    echo "Starting $NAME..."
+    aws ec2 run-instances \
+      --image-id $IMAGE \
+      --instance-type $TYPE \
+      --key-name $KEY \
+      --security-group-ids $GROUP \
+      --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=$NAME}]" \
+      --metadata-options "HttpTokens=optional" \
+      --block-device-mappings "$mapping" \
+      --count 1 \
+      --output json \
+      --user-data file://$DIR/aws.yml
+    ;;
+  stop)
+    echo "Stopping $NAME..."
+		ID=$(aws ec2 describe-instances \
+    			--filters "Name=tag:Name,Values=$NAME" \
+    			          "Name=instance-state-name,Values=running" \
+    			--query "Reservations[*].Instances[*].InstanceId" \
+    			--output text)
+    if [[ -z $ID ]] ; then
+      echo "No running vm found."
+      exit 1
+    fi
+    aws ec2 terminate-instances --instance-ids $ID
+    ;;
+  *)
+    echo 'Usage: bin/azure.sh start|stop'
+    exit 1
+    ;;
+esac
+

--- a/bin/aws.sh
+++ b/bin/aws.sh
@@ -73,11 +73,11 @@ case $command in
     ;;
   stop)
     echo "Stopping $NAME..."
-		ID=$(aws ec2 describe-instances \
-    			--filters "Name=tag:Name,Values=$NAME" \
-    			          "Name=instance-state-name,Values=running" \
-    			--query "Reservations[*].Instances[*].InstanceId" \
-    			--output text)
+    ID=$(aws ec2 describe-instances \
+            --filters "Name=tag:Name,Values=$NAME" \
+                      "Name=instance-state-name,Values=running" \
+            --query "Reservations[*].Instances[*].InstanceId" \
+            --output text)
     if [[ -z $ID ]] ; then
       echo "No running vm found."
       exit 1

--- a/bin/aws.yml
+++ b/bin/aws.yml
@@ -1,0 +1,31 @@
+#cloud-config
+package_update: true
+package_upgrade: true
+package_reboot_if_required: true
+package_repository: ppa:ansible/ansible
+packages:
+  - software-properties-common
+  - git
+  - ansible
+disk_setup:
+  /dev/nvme1n1:
+    table_type: 'mbr'
+    layout:
+      - 100
+    overwrite: true
+fs_setup:
+    - label: 'block_storage'
+      filesystem: 'ext4'
+      device: '/dev/nvme1n1'
+mounts:
+    - ["/dev/nvme1n1", "/mnt/block_storage", "ext4", "defaults", "0", "2"]
+runcmd:
+  - cat /dev/urandom | tr -dc 'a-zA-Z0-9_+-' | head -c 32 > /run/galaxy_api_key
+  - cat /dev/urandom | tr -dc 'a-zA-Z0-9_+-' | head -c 32 > /run/pulsar_api_key
+  - git clone https://github.com/galaxyproject/galaxy-k8s-boot.git /run/galaxy-k8s-boot
+  - cd /run/galaxy-k8s-boot && cat inventories/localhost.template | sed "s/__HOST__/$(curl -s ifconfig.me)/" | sed "s/__USER__/ubuntu/" > inventories/localhost
+  - cd /run/galaxy-k8s-boot && ansible-playbook -i inventories/localhost playbook.yml --extra-vars "job_max_cores=$(($(nproc) - 2))" --extra-vars "job_max_mem=$(($(free -m | awk '/^Mem:/{print $2}') - 6144))" --extra-vars "application=galaxy" --extra-vars "galaxy_api_key=$(cat /run/galaxy_api_key)" --extra-vars "pulsar_api_key=$(cat /run/pulsar_api_key)"
+
+
+
+

--- a/bin/azure.sh
+++ b/bin/azure.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+if [[ $# -eq 0 ]] ; then
+  echo 'Usage: bin/azure.sh start|stop'
+  exit 1
+fi
+
+az=/usr/local/bin/az
+
+NAME=ks-dev
+KEY=$HOME/.ssh/id_rsa.pub
+GROUP=JH-RIT-ANVIL-TEST-RG
+IMAGE=Canonical:ubuntu-24_04-lts:ubuntu-pro:latest
+TYPE=Standard_D16ds_v5
+
+DIR=$(dirname $(realpath $0))
+
+command=$1
+shift
+while [[ $# > 0 ]]; do
+  case $1 in
+    -n|--name) NAME=$2 ; shift ;;
+    -k|--key) KEY=$2 ; shift ;;
+    -g|--group) GROUP=$2 ; shift ;;
+    -i|--image) IMAGE=$2 ; shift ;;
+    -t|--type) TYPE=$2 ; shift ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+case $command in
+  start)
+    echo "Starting $NAME..."
+    $az vm create \
+      --resource-group $GROUP \
+      --name $NAME \
+      --image $IMAGE \
+      --size $TYPE \
+      --admin-username ubuntu \
+      --ssh-key-values $KEY \
+      --os-disk-size-gb 30 \
+      --output table \
+      --custom-data $DIR/azure.yml
+    $az vm open-port --resource-group $GROUP --name $NAME --port 80 --priority 102
+    ;;
+  stop)
+    echo "Stopping $NAME..."
+    $az vm delete --resource-group $GROUP --name $NAME --yes
+    ;;
+  *)
+    echo 'Usage: bin/azure.sh start|stop'
+    exit 1
+    ;;
+esac
+
+#az vm create --resource-group JH-RIT-ANVIL-TEST-RG --name ks-dev --image Canonical:ubuntu-24_04-lts:ubuntu-pro:latest --size Standard_D16ds_v5 --admin-username ubuntu --ssh-key-values /Users/suderman/.ssh/ks-cluster.pub --os-disk-size-gb 30 --output table --custom-data bin/azure.yml
+#az vm open-port --resource-group JH-RIT-ANVIL-TEST-RG --name ks-dev --port 22 --priority 1001
+#az vm open-port --resource-group JH-RIT-ANVIL-TEST-RG --name ks-dev --port 80 --priority 1002

--- a/bin/azure.sh
+++ b/bin/azure.sh
@@ -56,7 +56,3 @@ case $command in
     exit 1
     ;;
 esac
-
-#az vm create --resource-group JH-RIT-ANVIL-TEST-RG --name ks-dev --image Canonical:ubuntu-24_04-lts:ubuntu-pro:latest --size Standard_D16ds_v5 --admin-username ubuntu --ssh-key-values /Users/suderman/.ssh/ks-cluster.pub --os-disk-size-gb 30 --output table --custom-data bin/azure.yml
-#az vm open-port --resource-group JH-RIT-ANVIL-TEST-RG --name ks-dev --port 22 --priority 1001
-#az vm open-port --resource-group JH-RIT-ANVIL-TEST-RG --name ks-dev --port 80 --priority 1002

--- a/bin/azure.yml
+++ b/bin/azure.yml
@@ -1,0 +1,20 @@
+#cloud-config
+package_update: true
+package_upgrade: true
+package_reboot_if_required: true
+package_repository: ppa:ansible/ansible
+packages:
+  - software-properties-common
+  - git
+  - ansible
+runcmd:
+  - mkdir /mnt/block_storage
+  - cat /dev/urandom | tr -dc 'a-zA-Z0-9_+-' | head -c 32 > /run/galaxy_api_key
+  - cat /dev/urandom | tr -dc 'a-zA-Z0-9_+-' | head -c 32 > /run/pulsar_api_key
+  - git clone https://github.com/galaxyproject/galaxy-k8s-boot.git /run/galaxy-k8s-boot
+  - cd /run/galaxy-k8s-boot && cat inventories/localhost.template | sed "s/__HOST__/$(curl -s ifconfig.me)/" | sed "s/__USER__/ubuntu/" > inventories/localhost
+  - cd /run/galaxy-k8s-boot && ansible-playbook -i inventories/localhost playbook.yml --extra-vars "job_max_cores=$(($(nproc) - 2))" --extra-vars "job_max_mem=$(($(free -m | awk '/^Mem:/{print $2}') - 6144))" --extra-vars "application=galaxy" --extra-vars "galaxy_api_key=$(cat /run/galaxy_api_key)" --extra-vars "pulsar_api_key=$(cat /run/pulsar_api_key)"
+
+
+
+

--- a/docs/CloudConfig.md
+++ b/docs/CloudConfig.md
@@ -1,0 +1,92 @@
+# Cloud Config Examples
+
+
+Two example scripts are provided (`bin/aws.sh` and `bin/azure.sh`) that demostrate how to launch a VM with the necessary user data (`bin/aws.yml` and `bin/azure.yml` respectively) to run the Ansible playbook and install Galaxy. The `bin/aws.sh` script also creates a block storage device and mounts it to the VM as `/mnt/block_storage`. The block storage device is used to store the persistent data for Galaxy and Pulsar.  Equivalent functionality is available in Azure, but is not demonstrated in the provided script.
+
+## Prerequisites
+
+Users must have the following installed on their local machine:
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html)
+- [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli)
+
+Users must also have permission on AWS and Azure to create VMs, block storage devices, and manage network security groups.
+
+### Prerequistes (AWS)
+
+If you do not have a security group that allows incoming traffic on port 22 (SSH) and port 80 (HTTP), you can create a new security group with the following command:
+
+```bash
+# Find the VPC ID of the  VPC we want to attach the security group to.
+aws ec2 describe-vpcs --query "Vpcs[*].[VpcId,State,CidrBlock,IsDefault]"
+
+# Create a security group
+aws ec2 create-security-group \
+    --group-name my-security-group \
+    --description "A security group for testing Cloud config examples" \
+    --vpc-id <vpc-id>
+# Open ports 22, 80, and 6443
+aws ec2 authorize-security-group-ingress \
+    --group-name my-security-group \
+    --protocol tcp \
+    --port 22 \
+    --cidr $(curl -s ifconfig.me)/32
+			
+aws ec2 authorize-security-group-ingress \
+    --group-name my-security-group \
+    --protocol tcp \
+    --port 80 \
+    --cidr 0.0.0.0/0
+			
+aws ec2 authorize-security-group-ingress \
+    --group-name my-security-group \
+    --protocol tcp \
+    --port 6443 \
+    --cidr $(curl -s ifconfig.me)/32
+			
+```
+
+On AWS a SSH key pair must also be uploaded to the region you are launching the VM in. The key pair name must be specified in the `bin/aws.sh` script.
+
+```bash
+aws ec2 import-key-pairs --key-name my-ssh-key --public-key-material ~/.ssh/id_rsa.pub
+```
+
+## Configuration
+
+Both scripts have similar configuration options defined as environment variables at the top of each script.
+
+- **NAME**: The name of the VM<br/> 
+- **KEY**: The SSH key pair to use. On AWS this is the name of the key pair as created above. On Azure this is the path to the public key file.
+- **IMAGE**: The image to use.
+- **GROUP**: On AWS this is the name of the security group as created above. On Azure this is the name of the resource group.
+- **TYPE**: The instance type
+
+Users can either edit the script files to set these variables as desired or specify them on the command line when running the script.
+
+
+## Usage
+
+Starting an VM:
+```bash
+bin/aws.sh start
+bin/aws.sh start --name my-vm --key my-ssh-key --image ami-0c55b159cbfafe1f0 --group my-security-group --type t2.micro
+
+bin/azure.sh start
+bin/azure.sh start --name my-vm \
+    --key ~/.ssh/id_rsa.pub \
+    --image Canonical:ubuntu-24_04-lts:ubuntu-pro:latest \
+    --group JH-RIT-ANVIL-TEST-RG 
+    --type Standard_D16ds_v5
+```
+
+Stopping a VM
+
+```bash
+bin/aws.sh stop
+bin/aws.sh stop --name my-vm
+
+bin/azure.sh stop
+bin/azure.sh stop --name my-vm
+```
+
+**Note** If you started a VM by specifying the `--name` on the command line you will need to specify the same `--name` when stopping the VM.

--- a/docs/CloudConfig.md
+++ b/docs/CloudConfig.md
@@ -66,10 +66,10 @@ Users can either edit the script files to set these variables as desired or spec
 
 ## Usage
 
-Starting an VM:
+Starting a VM:
 ```bash
 bin/aws.sh start
-bin/aws.sh start --name my-vm --key my-ssh-key --image ami-0c55b159cbfafe1f0 --group my-security-group --type t2.micro
+bin/aws.sh start --name my-vm --key my-ssh-key --image ami-0c55b159cbfafe1f0 --group my-security-group --type m6a.2xlarge
 
 bin/azure.sh start
 bin/azure.sh start --name my-vm \


### PR DESCRIPTION
Add two scripts (`bin/aws.sh` and `bin/azure.sh`) that can `start`/`stop` Galaxy VMs on AWS/EC2 and Azure using *cloud-config* YAML files.  Some *magic* needs to happen on AWS/Azure for these scripts to work, but if you can launch VMs using the online consoles figuring out what needs to be done for the scripts should be straight-forward.