### PR TITLE
Fix malformed html in the values file.

### DIFF
--- a/values/accp.yml
+++ b/values/accp.yml
@@ -73,3 +73,7 @@ extraFileMappings:
                               </p>
                           </div>
                       </div>
+                  </div>
+              </div>
+          </body>
+      </html>


### PR DESCRIPTION
The `welcome.html` defined in the `accp.yml` values file contains numerous tags that are not closed properly.  These are land mines waiting to trip up future updates.  While browsers handle malformed HTML, correct is always better.