### PR TITLE
Parameterize the GitHub repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,32 @@ Galaxy will be available at `http://INSTANCE_IP/` once deployment completes
 - `-p, --project`: GCP project ID (default: anvil-and-terra-development)
 - `-s, --disk-size`: Size of persistent disk (default: 150GB)
 - `-z, --zone`: GCP zone (default: us-east4-c)
+- `-g, --git-repo`: Git repository URL (default: https://github.com/galaxyproject/galaxy-k8s-boot.git)
+- `-b, --git-branch`: Git branch to deploy (default: master)
 - `--ephemeral-only`: Create VM without persistent disk
+
+#### Examples
+
+**Basic deployment:**
+```bash
+bin/launch_vm.sh -k "ssh-rsa AAAAB3..." my-galaxy-vm
+```
+
+**Custom git repository and branch (for testing/development):**
+```bash
+bin/launch_vm.sh -k "ssh-rsa AAAAB3..." \
+  -g "https://github.com/username/galaxy-k8s-boot.git" \
+  -b "feature-branch" \
+  my-test-vm
+```
+
+**With custom machine type and larger disk:**
+```bash
+bin/launch_vm.sh -k "ssh-rsa AAAAB3..." \
+  -m "e2-standard-8" \
+  -s "500GB" \
+  my-production-vm
+```
 
 ### Manual Deployment
 

--- a/bin/launch_vm.sh
+++ b/bin/launch_vm.sh
@@ -13,6 +13,8 @@ MACHINE_IMAGE="galaxy-k8s-boot-v2025-11-14"
 BOOT_DISK_SIZE="100GB"
 DISK_SIZE="150GB"
 DISK_TYPE="pd-balanced"
+GIT_REPO="https://github.com/galaxyproject/galaxy-k8s-boot.git"
+GIT_BRANCH="master"
 
 # Parse command line arguments
 INSTANCE_NAME=""
@@ -37,6 +39,8 @@ Options:
   -s, --disk-size SIZE        Size of persistent disk (default: $DISK_SIZE)
   -k, --ssh-key SSH_KEY       SSH public key for ubuntu user (required)
   -m, --machine-type TYPE     Machine type (default: $MACHINE_TYPE)
+  -g, --git-repo REPO         Git repository URL (default: $GIT_REPO)
+  -b, --git-branch BRANCH     Git branch to deploy (default: $GIT_BRANCH)
   --ephemeral-only            Create VM without persistent disk
   -h, --help                  Show this help message
 
@@ -52,6 +56,9 @@ Examples:
 
   # Create VM without persistent storage (testing only)
   $0 -k "ssh-rsa AAAAB3..." --ephemeral-only my-galaxy-vm
+
+  # Launch VM with custom git repository and branch
+  $0 -k "ssh-rsa AAAAB3..." -g "https://github.com/username/galaxy-k8s-boot.git" -b "feature-branch" my-galaxy-vm
 
 EOF
 }
@@ -85,6 +92,14 @@ while [[ $# -gt 0 ]]; do
             ;;
         -m|--machine-type)
             MACHINE_TYPE="$2"
+            shift 2
+            ;;
+        -g|--git-repo)
+            GIT_REPO="$2"
+            shift 2
+            ;;
+        -b|--git-branch)
+            GIT_BRANCH="$2"
             shift 2
             ;;
         --ephemeral-only)
@@ -137,6 +152,8 @@ echo "Project: $PROJECT"
 echo "Zone: $ZONE"
 echo "Machine Type: $MACHINE_TYPE"
 echo "Machine Image: $MACHINE_IMAGE"
+echo "Git Repository: $GIT_REPO"
+echo "Git Branch: $GIT_BRANCH"
 
 if [ "$EPHEMERAL_ONLY" = false ]; then
     echo "Disk Name: $DISK_NAME"
@@ -192,7 +209,7 @@ GCLOUD_CMD=(
 )
 
 # Build metadata string
-METADATA="ssh-keys=ubuntu:$SSH_KEY"
+METADATA="ssh-keys=ubuntu:$SSH_KEY,git-repo=${GIT_REPO},git-branch=${GIT_BRANCH}"
 if [ "$EPHEMERAL_ONLY" = false ]; then
     METADATA="${METADATA},persistent-volume-size=${PV_SIZE}Gi"
 fi

--- a/roles/galaxy_k8s_deployment/tasks/rke2_setup.yml
+++ b/roles/galaxy_k8s_deployment/tasks/rke2_setup.yml
@@ -55,3 +55,22 @@
 - name: Set kubeconfig path fact
   ansible.builtin.set_fact:
     kubeconfig_path: "/etc/rancher/rke2/rke2.yaml"
+
+- name: Create .kube directory for ubuntu user
+  ansible.builtin.file:
+    path: /home/ubuntu/.kube
+    state: directory
+    owner: ubuntu
+    group: ubuntu
+    mode: '0755'
+  become: true
+
+- name: Copy kubeconfig to ubuntu user home directory
+  ansible.builtin.copy:
+    src: /etc/rancher/rke2/rke2.yaml
+    dest: /home/ubuntu/.kube/config
+    owner: ubuntu
+    group: ubuntu
+    mode: '0600'
+    remote_src: true
+  become: true


### PR DESCRIPTION
Allow the GitHub repository and branch names to be specified in both the `bin/launch_vm.sh`  and the generated `user_data.sh` script.  Also copies the kubeconfig file to the `/home/ubuntu/.kube/` directory for easier retrieval.

These changes will make it easier for CI/CD pipelines if these can be specified rather than hard coded into the playbooks.