### PR TITLE
Allow multiple values files to be specified

### DIFF
--- a/PR2_DESCRIPTION.md
+++ b/PR2_DESCRIPTION.md
@@ -118,18 +118,33 @@ Added comprehensive "Advanced Configuration" section to README.md with:
 
 ## Troubleshooting and Fixes
 
-During testing, two issues were identified and resolved:
+During testing, several issues were identified and resolved:
 
 ### Issue #1: GCloud Metadata Delimiter Conflict
 **Problem**: Using comma-separated values files conflicted with gcloud's metadata format
 **Error**: `ERROR: (gcloud.compute.instances.create) argument --metadata: Bad syntax for dict arg`
-**Solution**: Changed delimiter from comma to semicolon in values files list (launch_vm.sh:181, user_data.sh:46)
+**Initial Solution**: Changed delimiter from comma to semicolon
 
 ### Issue #2: Cloud-init Quoting Issue
 **Problem**: Complex awk quoting with nested quotes broke inside cloud-init's bash -c command
 **Error**: `bash: -c: line 15: unexpected EOF while looking for matching ')'`
-**Solution**: Replaced awk with simpler sed command for JSON array conversion (user_data.sh:46)
+**Solution**: Replaced awk with simpler sed command for JSON array conversion
 
-### Issue #3: GCloud Metadata Special Characters
-**Problem**: Semicolons and slashes in values file paths caused gcloud metadata parsing errors
-**Solution**: Use individual `--metadata` flags instead of one concatenated string (launch_vm.sh:231-238)
+### Issue #3: GCloud Metadata Multiple Parameters Error
+**Problem**: GCloud doesn't support multiple `--metadata` flags
+**Error**: `ERROR: (gcloud.compute.instances.create) argument --metadata: "metadata" argument cannot be specified multiple times`
+**Final Solution**: Generate custom user_data.sh with values baked in instead of passing through metadata
+
+### Issue #4: Ansible JSON Array Parsing
+**Problem**: Values files were passed as string instead of JSON array to Ansible
+**Error**: `Invalid data passed to 'loop', it requires a list, got this instead: [values/values.yml,...]`
+**Solution**: Use proper JSON object format for entire `--extra-vars` parameter
+
+## Final Implementation
+
+The final solution generates a temporary user_data.sh script with all configuration values directly substituted:
+- Avoids all metadata parameter passing complexity
+- Eliminates special character escaping issues
+- Makes the solution more portable across cloud providers
+- Simplifies debugging (can inspect the generated script)
+- Properly formats extra-vars as JSON object for Ansible

--- a/PR2_DESCRIPTION.md
+++ b/PR2_DESCRIPTION.md
@@ -1,0 +1,135 @@
+# PR #2: Add support for multiple Helm values files
+
+## Summary
+
+This PR adds support for using multiple Helm values files when deploying Galaxy, enabling composable configuration patterns. It includes both Ansible role changes for direct playbook usage and command-line interface enhancements for VM launches.
+
+## Changes
+
+### Ansible Role Changes
+- Update `galaxy_values_files` to accept a list of files
+- Maintain backward compatibility with `galaxy_values_file` (single file, deprecated)
+- Copy multiple values files to remote host with indexed filenames
+- Pass all values files to Helm install using sequence lookup
+- Add comprehensive documentation with usage examples
+- Support composable configuration pattern
+
+### VM Launch Script Changes
+- Add `--galaxy-chart-version` parameter to specify Galaxy Helm chart version
+- Add `--galaxy-deps-version` parameter to specify Galaxy dependencies chart version
+- Add `-f|--values` parameter (can be specified multiple times) for Helm values files
+- Order of values files is preserved (later files override earlier ones)
+- Values are passed to VM via GCP instance metadata
+- `user_data.sh` reads metadata and passes to `ansible-pull` as extra-vars
+- Fix variable name bug in `user_data.sh` (PERSISTENT_DISK_SIZE → PV_SIZE)
+
+## Benefits
+
+This allows users to:
+- Separate base configuration from environment-specific overrides
+- Maintain common settings across deployments
+- Add optional features (e.g., GCP Batch configuration) via additional values files
+- Follow infrastructure-as-code best practices with modular configuration
+
+## Backward Compatibility
+
+The change is fully backward compatible:
+- Existing playbooks using `galaxy_values_file` (string) continue to work
+- New `galaxy_values_files` (list) variable is the recommended approach
+- Falls back to `values/values.yml` if neither variable is specified
+
+## Usage Examples
+
+### Ansible Playbook Usage
+
+#### Single file (backward compatible)
+```bash
+ansible-playbook -i inventory playbook.yml \
+  --extra-vars "galaxy_values_file=values/custom.yml"
+```
+
+#### Multiple files
+```bash
+ansible-playbook -i inventory playbook.yml \
+  -e galaxy_values_files='["values/base.yml","values/prod.yml","values/gcp-batch.yml"]'
+```
+
+### VM Launch Script Usage
+
+#### Specify chart versions
+```bash
+bin/launch_vm.sh -k "ssh-rsa AAAAB3..." \
+  --galaxy-chart-version "6.0.0" \
+  --galaxy-deps-version "1.1.0" \
+  my-galaxy-vm
+```
+
+#### Multiple values files (order matters - later files override earlier ones)
+```bash
+bin/launch_vm.sh -k "ssh-rsa AAAAB3..." \
+  -f values/values.yml \
+  -f values/gcp-batch.yml \
+  my-galaxy-vm
+```
+
+#### Combined usage with long-form parameters
+```bash
+bin/launch_vm.sh -k "ssh-rsa AAAAB3..." \
+  --galaxy-chart-version "6.0.0" \
+  --values values/values.yml \
+  --values values/dev.yml \
+  --values values/v25.0.2.yml \
+  my-test-vm
+```
+
+## Testing
+
+### Ansible Role Testing
+- Single values file using deprecated `galaxy_values_file`
+- Multiple values files using `galaxy_values_files`
+- Default behavior (no variables specified)
+
+### VM Launch Script Testing
+- Chart version parameters (--galaxy-chart-version, --galaxy-deps-version)
+- Single values file with -f parameter
+- Multiple values files with repeated -f/--values parameters
+- Order preservation of values files (array → CSV → JSON → Ansible)
+- Metadata passing from launch_vm.sh to user_data.sh
+- Default behavior when no parameters specified
+
+## Files Modified
+
+### Ansible Role Files
+- `roles/galaxy_k8s_deployment/defaults/main.yml` - Added galaxy_values_files list support
+- `roles/galaxy_k8s_deployment/tasks/galaxy_application.yml` - Implemented multi-file handling
+- `README.md` - Added "Advanced Configuration" section
+
+### VM Launch Files
+- `bin/launch_vm.sh` - Added chart version and values file parameters; fixed gcloud metadata passing
+- `bin/user_data.sh` - Added metadata reading and ansible-pull parameter passing; fixed cloud-init quoting
+
+## Documentation
+
+Added comprehensive "Advanced Configuration" section to README.md with:
+- Usage examples for single and multiple files
+- Example composable configuration setup
+- Best practices for organizing values files
+- VM launch script parameter documentation and examples
+
+## Troubleshooting and Fixes
+
+During testing, two issues were identified and resolved:
+
+### Issue #1: GCloud Metadata Delimiter Conflict
+**Problem**: Using comma-separated values files conflicted with gcloud's metadata format
+**Error**: `ERROR: (gcloud.compute.instances.create) argument --metadata: Bad syntax for dict arg`
+**Solution**: Changed delimiter from comma to semicolon in values files list (launch_vm.sh:181, user_data.sh:46)
+
+### Issue #2: Cloud-init Quoting Issue
+**Problem**: Complex awk quoting with nested quotes broke inside cloud-init's bash -c command
+**Error**: `bash: -c: line 15: unexpected EOF while looking for matching ')'`
+**Solution**: Replaced awk with simpler sed command for JSON array conversion (user_data.sh:46)
+
+### Issue #3: GCloud Metadata Special Characters
+**Problem**: Semicolons and slashes in values file paths caused gcloud metadata parsing errors
+**Solution**: Use individual `--metadata` flags instead of one concatenated string (launch_vm.sh:231-238)

--- a/README.md
+++ b/README.md
@@ -134,6 +134,82 @@ sudo tail -n +1 -f /var/log/cloud-init-output.log
 sudo journalctl -f -u cloud-final
 ```
 
+## Advanced Configuration
+
+### Using Multiple Helm Values Files
+
+The Galaxy deployment supports using multiple Helm values files, which allows you to compose configurations from different sources. This is useful for:
+- Separating base configuration from environment-specific overrides
+- Maintaining common settings across deployments
+- Adding optional features (like GCP Batch) via additional values files
+
+#### Single Values File (Default)
+
+By default, the playbook uses `values/values.yml`:
+
+```bash
+ansible-playbook -i inventories/vm.ini playbook.yml
+```
+
+You can specify a different single file:
+
+```bash
+ansible-playbook -i inventories/vm.ini playbook.yml \
+  --extra-vars "galaxy_values_file=values/custom.yml"
+```
+
+#### Multiple Values Files
+
+To use multiple values files, pass a list to `galaxy_values_files`:
+
+```bash
+ansible-playbook -i inventories/vm.ini playbook.yml \
+  --extra-vars '{"galaxy_values_files": ["values/values.yml", "values/gcp-batch.yml"]}'
+```
+
+Or using JSON syntax:
+
+```bash
+ansible-playbook -i inventories/vm.ini playbook.yml \
+  -e galaxy_values_files='["values/base.yml","values/prod.yml"]'
+```
+
+Files are applied in order, with later files overriding earlier ones (following Helm's standard behavior).
+
+#### Example: Composing Configurations
+
+Create separate values files for different purposes:
+
+```yaml
+# values/base.yml - Common settings
+persistence:
+  size: "20Gi"
+postgresql:
+  galaxyDatabasePassword: "changeme"
+
+# values/production.yml - Production-specific settings
+persistence:
+  size: "100Gi"
+configs:
+  galaxy.yml:
+    galaxy:
+      admin_users: "admin@example.com"
+
+# values/gcp-batch.yml - GCP Batch job runner
+configs:
+  job_conf.yml:
+    runners:
+      gcp_batch:
+        load: galaxy.jobs.runners.gcp_batch:GCPBatchJobRunner
+```
+
+Then deploy with:
+
+```bash
+ansible-playbook -i inventories/vm.ini playbook.yml \
+  -e galaxy_values_files='["values/base.yml","values/production.yml","values/gcp-batch.yml"]'
+```
+
 ## Deleting the VM
 
 > [!CAUTION]

--- a/bin/launch_vm.sh
+++ b/bin/launch_vm.sh
@@ -228,14 +228,14 @@ GCLOUD_CMD=(
     --metadata-from-file=user-data=bin/user_data.sh
 )
 
-# Build metadata string
-METADATA="ssh-keys=ubuntu:$SSH_KEY,galaxy-chart-version=${GALAXY_CHART_VERSION},galaxy-deps-version=${GALAXY_DEPS_VERSION},galaxy-values-files=${GALAXY_VALUES_FILES_LIST}"
+# Add metadata using separate flags to avoid parsing issues with special characters
+GCLOUD_CMD+=(--metadata ssh-keys="ubuntu:$SSH_KEY")
+GCLOUD_CMD+=(--metadata galaxy-chart-version="${GALAXY_CHART_VERSION}")
+GCLOUD_CMD+=(--metadata galaxy-deps-version="${GALAXY_DEPS_VERSION}")
+GCLOUD_CMD+=(--metadata galaxy-values-files="${GALAXY_VALUES_FILES_LIST}")
 if [ "$EPHEMERAL_ONLY" = false ]; then
-    METADATA="${METADATA},persistent-volume-size=${PV_SIZE}Gi"
+    GCLOUD_CMD+=(--metadata persistent-volume-size="${PV_SIZE}Gi")
 fi
-
-# Add combined metadata
-GCLOUD_CMD+=(--metadata="$METADATA")
 
 # Add disk flag if not ephemeral only
 if [ "$EPHEMERAL_ONLY" = false ]; then

--- a/bin/launch_vm.sh
+++ b/bin/launch_vm.sh
@@ -210,6 +210,106 @@ else
     echo "ℹ Using ephemeral storage only (no persistent disk)."
 fi
 
+# Generate custom user_data.sh with values baked in
+TEMP_USER_DATA=$(mktemp /tmp/user_data.XXXXXX.sh)
+trap "rm -f $TEMP_USER_DATA" EXIT
+
+cat > "$TEMP_USER_DATA" << 'EOF'
+#cloud-config
+runcmd:
+  - |
+    # Setup persistent disk if available
+    DISK_DEVICE="/dev/disk/by-id/google-galaxy-data"
+    if [ -b "$DISK_DEVICE" ]; then
+      echo "[`date`] - Found persistent disk at $DISK_DEVICE"
+
+      # Check if disk is already formatted
+      if ! blkid "$DISK_DEVICE" > /dev/null 2>&1; then
+        echo "[`date`] - Formatting disk $DISK_DEVICE with ext4"
+        mkfs -t ext4 "$DISK_DEVICE"
+      else
+        echo "[`date`] - Disk $DISK_DEVICE is already formatted"
+      fi
+
+      # Create mount point and mount
+      mkdir -p /mnt/block_storage
+      mount "$DISK_DEVICE" /mnt/block_storage
+
+      # Add to fstab for persistent mounting across reboots
+      DISK_UUID=$(blkid -s UUID -o value "$DISK_DEVICE")
+      if ! grep -q "$DISK_UUID" /etc/fstab; then
+        echo "UUID=$DISK_UUID /mnt/block_storage ext4 defaults 0 2" >> /etc/fstab
+      fi
+
+      # Set proper ownership
+      chown ubuntu:ubuntu /mnt/block_storage
+      echo "[`date`] - Persistent disk mounted at /mnt/block_storage"
+    else
+      echo "[`date`] - No persistent disk found. Galaxy will use ephemeral storage."
+    fi
+  - |
+    # Run ansible-pull as ubuntu user
+    sudo -u ubuntu bash -c '
+    export HOME=/home/ubuntu
+    HOST_IP=$(curl -s ifconfig.me)
+
+EOF
+
+# Add the configuration values directly into the script
+if [ "$EPHEMERAL_ONLY" = false ]; then
+    PV_SIZE_VALUE="${PV_SIZE}Gi"
+else
+    PV_SIZE_VALUE="20Gi"
+fi
+
+# Convert values files list to JSON array
+GALAXY_VALUES_FILES_JSON=$(echo "$GALAXY_VALUES_FILES_LIST" | sed -e 's/;/","/g' -e 's/^/["/' -e 's/$/"]/')
+
+cat >> "$TEMP_USER_DATA" << EOF
+    # Configuration from launch_vm.sh
+    PV_SIZE="${PV_SIZE_VALUE}"
+    GIT_REPO="${GIT_REPO}"
+    GIT_BRANCH="${GIT_BRANCH}"
+    GALAXY_CHART_VERSION="${GALAXY_CHART_VERSION}"
+    GALAXY_DEPS_VERSION="${GALAXY_DEPS_VERSION}"
+    GALAXY_VALUES_FILES_JSON='${GALAXY_VALUES_FILES_JSON}'
+EOF
+
+cat >> "$TEMP_USER_DATA" << 'EOF'
+
+    mkdir -p /tmp/ansible-inventory
+    cat > /tmp/ansible-inventory/localhost << INVEOF
+    [vm]
+    127.0.0.1 ansible_connection=local ansible_python_interpreter="/usr/bin/python3"
+
+    [all:vars]
+    ansible_user="ubuntu"
+    rke2_token="defaultSecret12345"
+    rke2_additional_sans=["${HOST_IP}"]
+    rke2_debug=true
+    nfs_size="${PV_SIZE}"
+    galaxy_persistence_size="${PV_SIZE}"
+    galaxy_db_password="gxy-db-password"
+    galaxy_user="dev@galaxyproject.org"
+    INVEOF
+
+    echo "[`date`] - NFS storage size for Galaxy: ${PV_SIZE}"
+    echo "[`date`] - Git Repository: ${GIT_REPO}"
+    echo "[`date`] - Git Branch: ${GIT_BRANCH}"
+    echo "[`date`] - Galaxy Chart Version: ${GALAXY_CHART_VERSION}"
+    echo "[`date`] - Galaxy Deps Version: ${GALAXY_DEPS_VERSION}"
+    echo "[`date`] - Galaxy Values Files: ${GALAXY_VALUES_FILES_JSON}"
+    echo "[`date`] - Inventory file created at /tmp/ansible-inventory/localhost; running ansible-pull..."
+
+    ANSIBLE_CALLBACKS_ENABLED=profile_tasks ANSIBLE_HOST_PATTERN_MISMATCH=ignore ansible-pull -U ${GIT_REPO} -C ${GIT_BRANCH} -d /home/ubuntu/ansible -i /tmp/ansible-inventory/localhost --accept-host-key --limit 127.0.0.1 --extra-vars "{\"galaxy_chart_version\": \"${GALAXY_CHART_VERSION}\", \"galaxy_deps_version\": \"${GALAXY_DEPS_VERSION}\", \"galaxy_values_files\": ${GALAXY_VALUES_FILES_JSON}}" playbook.yml
+
+    echo "[`date`] - User data script completed."
+    '
+
+EOF
+
+echo "ℹ Generated custom user_data.sh at $TEMP_USER_DATA"
+
 # Launch the VM
 echo "Launching VM '$INSTANCE_NAME'..."
 
@@ -225,17 +325,9 @@ GCLOUD_CMD=(
     --boot-disk-type="$DISK_TYPE"
     --tags=k8s,http-server,https-server
     --scopes=cloud-platform
-    --metadata-from-file=user-data=bin/user_data.sh
+    --metadata-from-file=user-data="$TEMP_USER_DATA"
+    --metadata=ssh-keys="ubuntu:$SSH_KEY"
 )
-
-# Add metadata using separate flags to avoid parsing issues with special characters
-GCLOUD_CMD+=(--metadata ssh-keys="ubuntu:$SSH_KEY")
-GCLOUD_CMD+=(--metadata galaxy-chart-version="${GALAXY_CHART_VERSION}")
-GCLOUD_CMD+=(--metadata galaxy-deps-version="${GALAXY_DEPS_VERSION}")
-GCLOUD_CMD+=(--metadata galaxy-values-files="${GALAXY_VALUES_FILES_LIST}")
-if [ "$EPHEMERAL_ONLY" = false ]; then
-    GCLOUD_CMD+=(--metadata persistent-volume-size="${PV_SIZE}Gi")
-fi
 
 # Add disk flag if not ephemeral only
 if [ "$EPHEMERAL_ONLY" = false ]; then

--- a/bin/launch_vm.sh
+++ b/bin/launch_vm.sh
@@ -161,8 +161,9 @@ if [ ${#GALAXY_VALUES_FILES[@]} -eq 0 ]; then
     GALAXY_VALUES_FILES=("values/values.yml")
 fi
 
-# Convert values files array to comma-separated string for metadata
-GALAXY_VALUES_FILES_CSV=$(IFS=,; echo "${GALAXY_VALUES_FILES[*]}")
+# Convert values files array to semicolon-separated string for metadata
+# (semicolon is used instead of comma to avoid conflicts with gcloud metadata format)
+GALAXY_VALUES_FILES_LIST=$(IFS=';'; echo "${GALAXY_VALUES_FILES[*]}")
 
 echo "=== Galaxy Kubernetes Boot VM Launch ==="
 echo "Instance Name: $INSTANCE_NAME"
@@ -228,7 +229,7 @@ GCLOUD_CMD=(
 )
 
 # Build metadata string
-METADATA="ssh-keys=ubuntu:$SSH_KEY,galaxy-chart-version=${GALAXY_CHART_VERSION},galaxy-deps-version=${GALAXY_DEPS_VERSION},galaxy-values-files=${GALAXY_VALUES_FILES_CSV}"
+METADATA="ssh-keys=ubuntu:$SSH_KEY,galaxy-chart-version=${GALAXY_CHART_VERSION},galaxy-deps-version=${GALAXY_DEPS_VERSION},galaxy-values-files=${GALAXY_VALUES_FILES_LIST}"
 if [ "$EPHEMERAL_ONLY" = false ]; then
     METADATA="${METADATA},persistent-volume-size=${PV_SIZE}Gi"
 fi

--- a/bin/user_data.sh
+++ b/bin/user_data.sh
@@ -43,7 +43,7 @@ runcmd:
     GALAXY_VALUES_FILES_LIST=$(curl -s -f "http://metadata.google.internal/computeMetadata/v1/instance/attributes/galaxy-values-files" -H "Metadata-Flavor: Google" 2>/dev/null || echo "values/values.yml")
 
     # Convert semicolon-separated values files to JSON array for Ansible
-    GALAXY_VALUES_FILES_JSON=$(echo "$GALAXY_VALUES_FILES_LIST" | awk -F';' '"'"'{printf "["; for(i=1; i<=NF; i++) {if(i>1) printf ","; printf "\"%s\"", $i} printf "]"}'"'"')
+    GALAXY_VALUES_FILES_JSON=$(echo "$GALAXY_VALUES_FILES_LIST" | sed -e 's/;/","/g' -e 's/^/["/' -e 's/$/"]/')
 
     mkdir -p /tmp/ansible-inventory
     cat > /tmp/ansible-inventory/localhost << EOF

--- a/bin/user_data.sh
+++ b/bin/user_data.sh
@@ -40,10 +40,10 @@ runcmd:
     PV_SIZE=$(curl -s -f "http://metadata.google.internal/computeMetadata/v1/instance/attributes/persistent-volume-size" -H "Metadata-Flavor: Google" 2>/dev/null || echo "20Gi")
     GALAXY_CHART_VERSION=$(curl -s -f "http://metadata.google.internal/computeMetadata/v1/instance/attributes/galaxy-chart-version" -H "Metadata-Flavor: Google" 2>/dev/null || echo "6.6.0")
     GALAXY_DEPS_VERSION=$(curl -s -f "http://metadata.google.internal/computeMetadata/v1/instance/attributes/galaxy-deps-version" -H "Metadata-Flavor: Google" 2>/dev/null || echo "1.1.1")
-    GALAXY_VALUES_FILES_CSV=$(curl -s -f "http://metadata.google.internal/computeMetadata/v1/instance/attributes/galaxy-values-files" -H "Metadata-Flavor: Google" 2>/dev/null || echo "values/values.yml")
+    GALAXY_VALUES_FILES_LIST=$(curl -s -f "http://metadata.google.internal/computeMetadata/v1/instance/attributes/galaxy-values-files" -H "Metadata-Flavor: Google" 2>/dev/null || echo "values/values.yml")
 
-    # Convert comma-separated values files to JSON array for Ansible
-    GALAXY_VALUES_FILES_JSON=$(echo "$GALAXY_VALUES_FILES_CSV" | awk -F, '"'"'{printf "["; for(i=1; i<=NF; i++) {if(i>1) printf ","; printf "\"%s\"", $i} printf "]"}'"'"')
+    # Convert semicolon-separated values files to JSON array for Ansible
+    GALAXY_VALUES_FILES_JSON=$(echo "$GALAXY_VALUES_FILES_LIST" | awk -F';' '"'"'{printf "["; for(i=1; i<=NF; i++) {if(i>1) printf ","; printf "\"%s\"", $i} printf "]"}'"'"')
 
     mkdir -p /tmp/ansible-inventory
     cat > /tmp/ansible-inventory/localhost << EOF
@@ -64,7 +64,7 @@ runcmd:
     echo "[`date`] - NFS storage size for Galaxy: ${PV_SIZE}"
     echo "[`date`] - Galaxy Chart Version: ${GALAXY_CHART_VERSION}"
     echo "[`date`] - Galaxy Deps Version: ${GALAXY_DEPS_VERSION}"
-    echo "[`date`] - Galaxy Values Files: ${GALAXY_VALUES_FILES_CSV}"
+    echo "[`date`] - Galaxy Values Files: ${GALAXY_VALUES_FILES_LIST}"
     echo "[`date`] - Inventory file created at /tmp/ansible-inventory/localhost; running ansible-pull..."
 
     ANSIBLE_CALLBACKS_ENABLED=profile_tasks ANSIBLE_HOST_PATTERN_MISMATCH=ignore ansible-pull -U https://github.com/galaxyproject/galaxy-k8s-boot.git -C master -d /home/ubuntu/ansible -i /tmp/ansible-inventory/localhost --accept-host-key --limit 127.0.0.1 --extra-vars "galaxy_chart_version=${GALAXY_CHART_VERSION}" --extra-vars "galaxy_deps_version=${GALAXY_DEPS_VERSION}" --extra-vars "galaxy_values_files=${GALAXY_VALUES_FILES_JSON}" playbook.yml

--- a/roles/galaxy_k8s_deployment/defaults/main.yml
+++ b/roles/galaxy_k8s_deployment/defaults/main.yml
@@ -59,7 +59,16 @@ ingress_version: "4.13.2"  # https://github.com/kubernetes/ingress-nginx?tab=rea
 galaxy_chart: cloudve/galaxy
 galaxy_chart_version: "6.6.0"
 galaxy_deps_version: "1.1.1"
-galaxy_values_file: "values/values.yml"
+
+# Galaxy Helm values files configuration
+# Supports both single file (string, deprecated) and multiple files (list)
+# Examples:
+#   galaxy_values_file: "values/values.yml"  # Single file (backward compatible)
+#   galaxy_values_files: ["values/values.yml", "values/custom.yml"]  # Multiple files
+galaxy_values_file: ""  # Deprecated - use galaxy_values_files instead
+galaxy_values_files:
+  - "values/values.yml"
+
 galaxy_persistence_size: "20Gi"
 galaxy_db_password: "galaxydbpassword"
 galaxy_user: "default-user@galaxyproject.org"

--- a/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
+++ b/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
@@ -28,11 +28,30 @@
     state: present
     kubeconfig: "{{ kubeconfig_path }}"
 
-- name: Copy the values file to the remote host
+# Prepare values files list with backward compatibility
+- name: Prepare Galaxy values files list
+  set_fact:
+    _galaxy_values_files: >-
+      {%- if galaxy_values_file is defined and galaxy_values_file != "" -%}
+        {{ [galaxy_values_file] }}
+      {%- elif galaxy_values_files is defined and galaxy_values_files | length > 0 -%}
+        {{ galaxy_values_files }}
+      {%- else -%}
+        {{ ['values/values.yml'] }}
+      {%- endif -%}
+
+- name: Display Galaxy values files being used
+  debug:
+    msg: "Using Galaxy Helm values files: {{ _galaxy_values_files }}"
+
+- name: Copy Galaxy values files to the remote host
   ansible.builtin.copy:
-    src: "{{ galaxy_values_file }}"
-    dest: /tmp/values.yml
+    src: "{{ item }}"
+    dest: "/tmp/galaxy_values_{{ idx }}.yml"
     mode: '0644'
+  loop: "{{ _galaxy_values_files }}"
+  loop_control:
+    index_var: idx
 
 - name: Helm install Galaxy
   kubernetes.core.helm:
@@ -42,8 +61,7 @@
     chart_version: "{{ galaxy_chart_version }}"
     kubeconfig: "{{ kubeconfig_path }}"
     update_repo_cache: true
-    values_files:
-      - /tmp/values.yml
+    values_files: "{{ lookup('sequence', 'start=0 end=' ~ (_galaxy_values_files|length - 1) ~ ' format=/tmp/galaxy_values_%d.yml', wantlist=True) }}"
     values:
       persistence:
         size: "{{ galaxy_persistence_size }}"

--- a/roles/galaxy_k8s_deployment/tasks/rke2_setup.yml
+++ b/roles/galaxy_k8s_deployment/tasks/rke2_setup.yml
@@ -55,3 +55,22 @@
 - name: Set kubeconfig path fact
   ansible.builtin.set_fact:
     kubeconfig_path: "/etc/rancher/rke2/rke2.yaml"
+
+- name: Create .kube directory for ubuntu user
+  ansible.builtin.file:
+    path: /home/ubuntu/.kube
+    state: directory
+    owner: ubuntu
+    group: ubuntu
+    mode: '0755'
+  become: true
+
+- name: Copy kubeconfig to ubuntu user home directory
+  ansible.builtin.copy:
+    src: /etc/rancher/rke2/rke2.yaml
+    dest: /home/ubuntu/.kube/config
+    owner: ubuntu
+    group: ubuntu
+    mode: '0600'
+    remote_src: true
+  become: true

--- a/values/batch.yml
+++ b/values/batch.yml
@@ -1,0 +1,94 @@
+
+configs:
+  job_conf.yml:
+    runners:
+      gcp_batch:
+        load: galaxy.jobs.runners.gcp_batch:GoogleCloudBatchJobRunner
+        workers: 4
+        # Basic GCP settings
+        project_id: anvil-and-terra-development
+        region: us-east4
+#        service_account_file: /etc/secrets/galaxy/key.json
+        service_account_email: galaxy-batch-runner@anvil-and-terra-development.iam.gserviceaccount.com
+
+        # NFS configuration (required)
+        # nfs_server is set dynamically by the playbook via helm_values_gcp_batch
+        nfs_path: /             # Root path on NFS server. This will be updated by the playbook.
+        nfs_mount_path: /galaxy/server/database # Mount point in Batch VMs
+
+        # Network configuration (required for NFS access)
+        network: default
+        subnet: default
+
+        # Compute resources (defaults shown)
+        machine_type: n2-standard-4
+        vcpu: 1.0
+        memory_mib: 2048
+        boot_disk_size_gb: 100
+        boot_disk_type: pd-standard
+
+        # Container settings
+        use_container: true
+        container_image: ksuderman/galaxy-min:25.1-batch-2  # fallback if tool doesn't specify
+        galaxy_user_id: 10001
+        galaxy_group_id: 10001
+
+        # Custom VM image with CVMFS pre-configured (update date as needed)
+#        custom_vm_image: projects/anvil-and-terra-development/global/images/galaxy-k8s-boot-v2025-09-26
+        custom_vm_image: projects/anvil-and-terra-development/global/images/galaxy-batch-debian12-20251118
+        # Job execution settings
+        max_retry_count: 3
+        max_run_duration: 3600s
+        polling_interval: 30
+    execution:
+      default: tpv_dispatcher
+      environments:
+        local:
+          runner: local
+        gcp_batch:
+          runner: gcp_batch
+          # Override runner parameters if needed
+          container_image: ubuntu:20.04
+          machine_type: e2-standard-4
+    destinations:
+      - id: gcp_batch_default
+        runner: gcp_batch
+      - id: k8s_default
+        runner: k8s
+      - id: local_default
+        runner: local
+    tools:
+      - environment: local
+        id: upload1
+      - environment: local
+        id: __DATA_FETCH__
+      - environment: local
+        id: __EXPORT_HISTORY__
+      - environment: local
+        id: __IMPORT_HISTORY__
+      - environment: local
+        id: __SET_METADATA__
+      - environment: local
+        id: __EXTRACT_DATASET__
+      # Route interactive tools to Kubernetes
+      - environment: local
+        id: interactive_tool.*
+      # Route data source tools to Kubernetes
+      - environment: local
+        id: .*data_source.*
+      # Keep workflows internal to cluster
+      - environment: local
+        id: __EXPORT_WORKFLOW__
+      - environment: local
+        id: __IMPORT_WORKFLOW__
+
+jobs:
+   rules:
+    tpv_rules_local.yml:
+      destinations:
+        gcp_batch:
+          runner: gcp_batch
+          params:
+            docker_enabled: "true"
+            cores: "{cores}"
+            mem: "{mem}"

--- a/values/dev.yml
+++ b/values/dev.yml
@@ -1,0 +1,3 @@
+image:
+  repository: quay.io/galaxyproject/galaxy-min
+  tag: "dev"

--- a/values/resource-params.yml
+++ b/values/resource-params.yml
@@ -1,0 +1,27 @@
+configs:
+  galaxy.yml:
+    galaxy:
+      job_resource_params_file: "/galaxy/server/config/job_resource_params_conf.xml"
+  job_conf.yml:
+    resources:
+      default: default
+      groups:
+        default: [ processors, mem, time ]
+
+jobs:
+  user_limits:
+    cores: 16
+    mem: 64
+    walltime: 168
+
+extraFileMappings:
+  /galaxy/server/config/job_resource_params_conf.xml:
+    applyToWeb: true
+    applyToJob: true
+    applyToWorkflow: true
+    content: |
+      <parameters>
+        <param label="Processors" name="processors" type="integer" min="1" max="64" value="" help="Number of processing cores, 'ppn' value (1-64). Leave blank to use default value." />
+        <param label="Memory" name="mem" type="integer" min="1" max="1024" value="" help="Memory size in gigabytes, 'pmem' value (1-1024). Leave blank to use default value." />
+        <param label="Wall Time" name="time" type="integer" min="1" max="168" value="" help="Maximum job time in hours, 'walltime' value (1-168). Leave blank to use default value." />
+      </parameters>

--- a/values/rules.yml
+++ b/values/rules.yml
@@ -1,0 +1,13 @@
+jobs:
+  rules:
+    tpv_rules_local.yml:
+      tools:
+        toolshed.g2.bx.psu.edu/repos/iuc/metaphlan/metaphlan/.*:
+          cores: 16
+          mem: 96
+        toolshed.g2.bx.psu.edu/repos/iuc/fastp/fastp/.*:
+          cores: 8
+          mem: 32
+        toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/.*:
+          cores: 16
+          mem: 64

--- a/values/v25.0.2.yml
+++ b/values/v25.0.2.yml
@@ -1,0 +1,3 @@
+image:
+  repository: quay.io/galaxyproject/galaxy-min
+  tag: "25.0.2"

--- a/values/v25.1-auto.yml
+++ b/values/v25.1-auto.yml
@@ -1,0 +1,3 @@
+image:
+  repository: quay.io/galaxyproject/galaxy-min
+  tag: "25.1-auto"

--- a/values/v25.1-batch.yml
+++ b/values/v25.1-batch.yml
@@ -1,0 +1,3 @@
+image:
+  repository: ksuderman/galaxy-min
+  tag: "25.1-batch-2"


### PR DESCRIPTION
This PR adds support for using multiple Helm values files when deploying Galaxy, enabling composable configuration patterns. It includes both Ansible role changes for direct playbook usage and command-line interface enhancements for VM launches.

Also parameterizes the Helm chart version for the Galaxy Helm chart and the Galaxy Deps Helm chart.

## Changes

### Ansible Role Changes
- Update `galaxy_values_files` to accept a list of files
- Maintain backward compatibility with `galaxy_values_file` (single file, deprecated)
- Copy multiple values files to remote host with indexed filenames
- Pass all values files to Helm install using sequence lookup
- Add comprehensive documentation with usage examples
- Support composable configuration pattern

### VM Launch Script Changes
- Add `--galaxy-chart-version` parameter to specify Galaxy Helm chart version
- Add `--galaxy-deps-version` parameter to specify Galaxy dependencies chart version
- Add `-f|--values` parameter (can be specified multiple times) for Helm values files
- Order of values files is preserved (later files override earlier ones)
- Values are passed to VM via GCP instance metadata
- `user_data.sh` reads metadata and passes to `ansible-pull` as extra-vars
- Fix variable name bug in `user_data.sh` (PERSISTENT_DISK_SIZE → PV_SIZE)
