### PR TITLE
Enable GCP Batch job runner support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,77 @@ sudo tail -n +1 -f /var/log/cloud-init-output.log
 sudo journalctl -f -u cloud-final
 ```
 
+### GCP Batch Job Runner
+
+The Galaxy deployment can be configured to use Google Cloud Batch for job execution, allowing Galaxy to scale job processing independently of the Kubernetes cluster.
+
+#### Prerequisites
+
+1. **GCP Service Account**: Create a service account with appropriate permissions:
+   ```bash
+   gcloud iam service-accounts create galaxy-batch-runner \
+     --project=YOUR_PROJECT_ID
+
+   # Grant required permissions
+   gcloud projects add-iam-policy-binding YOUR_PROJECT_ID \
+     --member="serviceAccount:galaxy-batch-runner@YOUR_PROJECT_ID.iam.gserviceaccount.com" \
+     --role="roles/batch.jobsEditor"
+
+   gcloud projects add-iam-policy-binding YOUR_PROJECT_ID \
+     --member="serviceAccount:galaxy-batch-runner@YOUR_PROJECT_ID.iam.gserviceaccount.com" \
+     --role="roles/iam.serviceAccountUser"
+   ```
+
+2. **Firewall Rules**: Ensure GCP Batch VMs can access the NFS server:
+   ```bash
+   gcloud compute firewall-rules create allow-nfs-for-batch \
+     --project=YOUR_PROJECT_ID \
+     --direction=INGRESS \
+     --priority=1000 \
+     --network=default \
+     --action=ALLOW \
+     --rules=tcp:2049,udp:2049,tcp:111,udp:111 \
+     --source-ranges=10.0.0.0/8 \
+     --target-tags=k8s
+   ```
+
+3. **Kubernetes Secret**: Create a secret with the service account key:
+   ```bash
+   kubectl create secret generic gcp-batch-key \
+     --from-file=key.json=/path/to/service-account-key.json \
+     --namespace galaxy
+   ```
+
+#### Deployment
+
+Deploy Galaxy with GCP Batch enabled:
+
+```bash
+ansible-playbook -i inventories/vm.ini playbook.yml \
+  --extra-vars "enable_gcp_batch=true" \
+  --extra-vars "gcp_batch_service_account_email=galaxy-batch-runner@YOUR_PROJECT_ID.iam.gserviceaccount.com" \
+  --extra-vars "gcp_batch_region=us-east4"
+```
+
+Or combine with multiple values files:
+
+```bash
+ansible-playbook -i inventories/vm.ini playbook.yml \
+  -e enable_gcp_batch=true \
+  -e gcp_batch_service_account_email=galaxy-batch-runner@YOUR_PROJECT_ID.iam.gserviceaccount.com \
+  -e galaxy_values_files='["values/values.yml","values/gcp-batch.yml"]'
+```
+
+#### What Gets Configured Automatically
+
+When `enable_gcp_batch=true`, the playbook automatically:
+- **Detects NFS LoadBalancer IP**: Configures internal LoadBalancer for NFS with source IP restrictions
+- **Detects NFS Export Path**: Automatically finds the Galaxy PVC export path using `showmount`
+- **Updates job_conf.yml**: Injects NFS server IP and export path into GCP Batch runner configuration
+- **Restarts Deployments**: Applies configuration changes by restarting Galaxy pods
+
+No manual intervention required for NFS path detection or configuration updates.
+
 ## Deleting the VM
 
 > [!CAUTION]

--- a/roles/galaxy_k8s_deployment/defaults/main.yml
+++ b/roles/galaxy_k8s_deployment/defaults/main.yml
@@ -67,6 +67,17 @@ galaxy_api_key: ""
 galaxy_job_max_cores: 1
 galaxy_job_max_mem: 4
 
+# GCP Batch Configuration
+# Set enable_gcp_batch=true to configure Galaxy for GCP Batch job runner
+# This will:
+#   - Detect and configure NFS LoadBalancer IP
+#   - Auto-detect NFS export path for Galaxy PVC
+#   - Update job_conf.yml with GCP Batch runner configuration
+#   - Restart Galaxy deployments to apply changes
+enable_gcp_batch: false
+gcp_batch_service_account_email: ""
+gcp_batch_region: "us-east4"
+
 # Pulsar Application Configuration
 pulsar_chart: cloudve/pulsar
 pulsar_chart_version: "0.2.0"

--- a/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
+++ b/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
@@ -28,6 +28,49 @@
     state: present
     kubeconfig: "{{ kubeconfig_path }}"
 
+# ============================================================================
+# GCP Batch: NFS LoadBalancer IP Detection
+# ============================================================================
+- name: Wait for NFS LoadBalancer to be assigned
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Service
+    name: nfs-provisioner-nfs-server-provisioner
+    namespace: nfs-provisioner
+    kubeconfig: "{{ kubeconfig_path }}"
+    wait: true
+    wait_condition:
+      type: status.loadBalancer.ingress
+    wait_timeout: 300
+  register: nfs_service_info
+  retries: 10
+  delay: 10
+  until:
+    - nfs_service_info.resources | length > 0
+    - nfs_service_info.resources[0].status.loadBalancer is defined
+    - nfs_service_info.resources[0].status.loadBalancer.ingress is defined
+    - nfs_service_info.resources[0].status.loadBalancer.ingress | length > 0
+  when: enable_gcp_batch | default(false) | bool
+
+- name: Set NFS server IP from LoadBalancer for GCP Batch VPC access
+  set_fact:
+    nfs_server: "{{ nfs_service_info.resources[0].status.loadBalancer.ingress[0].ip }}"
+  when:
+    - enable_gcp_batch | default(false) | bool
+    - nfs_service_info.resources | length > 0
+
+- name: Fail if NFS service not found
+  fail:
+    msg: "NFS service not found. Make sure NFS setup completed successfully."
+  when:
+    - enable_gcp_batch | default(false) | bool
+    - nfs_service_info.resources | length == 0
+
+- name: Display NFS server access method
+  debug:
+    msg: "Using NFS LoadBalancer IP: {{ nfs_server }} (accessible from GCP Batch VMs)"
+  when: enable_gcp_batch | default(false) | bool
+
 - name: Copy the values file to the remote host
   ansible.builtin.copy:
     src: "{{ galaxy_values_file }}"
@@ -44,7 +87,9 @@
     update_repo_cache: true
     values_files:
       - /tmp/values.yml
-    values:
+    values: "{{ _helm_values_base | combine(_helm_values_gcp_batch if (enable_gcp_batch | default(false) | bool) else {}, recursive=True) }}"
+  vars:
+    _helm_values_base:
       persistence:
         size: "{{ galaxy_persistence_size }}"
       postgresql:
@@ -62,3 +107,101 @@
               k8s:
                 max_cores: "{{ galaxy_job_max_cores }}"
                 max_mem: "{{ galaxy_job_max_mem }}"
+    _helm_values_gcp_batch:
+      configs:
+        job_conf.yml:
+          runners:
+            gcp_batch:
+              nfs_server: "{{ nfs_server }}"
+
+# ============================================================================
+# GCP Batch: NFS Export Path Detection
+# ============================================================================
+- name: Wait for Galaxy PVC to be created
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: PersistentVolumeClaim
+    name: galaxy-galaxy-pvc
+    namespace: galaxy
+    kubeconfig: "{{ kubeconfig_path }}"
+    wait: true
+    wait_condition:
+      type: Bound
+      status: "True"
+    wait_timeout: 300
+  when: enable_gcp_batch | default(false) | bool
+
+- name: Detect NFS export path for Galaxy PVC
+  shell: |
+    # Wait a moment for NFS export to be available
+    sleep 10
+
+    # Get NFS exports and find the PVC export path
+    showmount -e {{ nfs_server }} | grep '/export/pvc-' | head -1 | awk '{print $1}'
+  register: nfs_export_detection
+  retries: 10
+  delay: 5
+  until: nfs_export_detection.stdout != ""
+  when: enable_gcp_batch | default(false) | bool
+
+- name: Set NFS export path for Galaxy database
+  set_fact:
+    nfs_export_path: "{{ nfs_export_detection.stdout }}"
+  when:
+    - enable_gcp_batch | default(false) | bool
+    - nfs_export_detection.stdout is defined
+    - nfs_export_detection.stdout != ""
+
+- name: Display detected NFS export path
+  debug:
+    msg: "Detected NFS export path for Galaxy PVC: {{ nfs_export_path }}"
+  when:
+    - enable_gcp_batch | default(false) | bool
+    - nfs_export_path is defined
+
+- name: Fail if NFS export path not detected
+  fail:
+    msg: "Could not detect NFS export path for Galaxy PVC. Available exports: {{ nfs_export_detection.stdout_lines | default('none') }}"
+  when:
+    - enable_gcp_batch | default(false) | bool
+    - nfs_export_path is not defined or nfs_export_path == ""
+
+# ============================================================================
+# GCP Batch: Update Configuration and Restart
+# ============================================================================
+- name: Get current job_conf.yml from ConfigMap
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: ConfigMap
+    name: galaxy-configs
+    namespace: galaxy
+    kubeconfig: "{{ kubeconfig_path }}"
+  register: galaxy_configs
+  when: enable_gcp_batch | default(false) | bool
+
+- name: Update job_conf.yml with NFS export path
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ kubeconfig_path }}"
+    definition:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: galaxy-configs
+        namespace: galaxy
+      data: "{{ galaxy_configs.resources[0].data | combine({'job_conf.yml': (galaxy_configs.resources[0].data['job_conf.yml'] | from_yaml | combine({'runners': {'gcp_batch': {'nfs_path': nfs_export_path}}}, recursive=True) | to_nice_yaml) }) }}"
+  when:
+    - enable_gcp_batch | default(false) | bool
+    - nfs_export_path is defined
+
+- name: Restart Galaxy deployments to pick up configuration changes
+  shell: kubectl rollout restart deployment {{ item }} -n galaxy
+  environment:
+    KUBECONFIG: "{{ kubeconfig_path }}"
+  loop:
+    - galaxy-web
+    - galaxy-workflow
+    - galaxy-job-0
+  when:
+    - enable_gcp_batch | default(false) | bool
+    - nfs_export_path is defined

--- a/roles/galaxy_k8s_deployment/tasks/nfs_setup.yml
+++ b/roles/galaxy_k8s_deployment/tasks/nfs_setup.yml
@@ -49,3 +49,24 @@
           - timeo=30
           - lock        # Enable NFS locking
           - hard        # Ensure reliable locking
+
+# ============================================================================
+# GCP Batch: Configure NFS LoadBalancer for internal access
+# ============================================================================
+- name: Patch NFS service for GCP Batch (internal LoadBalancer with source IP restrictions)
+  kubernetes.core.k8s:
+    state: present
+    kubeconfig: "{{ kubeconfig_path }}"
+    definition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: nfs-provisioner-nfs-server-provisioner
+        namespace: nfs-provisioner
+        annotations:
+          networking.gke.io/load-balancer-type: "Internal"
+      spec:
+        type: LoadBalancer
+        loadBalancerSourceRanges:
+          - "10.0.0.0/8"  # Restrict to internal GCP networks
+  when: enable_gcp_batch | default(false) | bool

--- a/roles/galaxy_k8s_deployment/tasks/rke2_setup.yml
+++ b/roles/galaxy_k8s_deployment/tasks/rke2_setup.yml
@@ -55,3 +55,22 @@
 - name: Set kubeconfig path fact
   ansible.builtin.set_fact:
     kubeconfig_path: "/etc/rancher/rke2/rke2.yaml"
+
+- name: Create .kube directory for ubuntu user
+  ansible.builtin.file:
+    path: /home/ubuntu/.kube
+    state: directory
+    owner: ubuntu
+    group: ubuntu
+    mode: '0755'
+  become: true
+
+- name: Copy kubeconfig to ubuntu user home directory
+  ansible.builtin.copy:
+    src: /etc/rancher/rke2/rke2.yaml
+    dest: /home/ubuntu/.kube/config
+    owner: ubuntu
+    group: ubuntu
+    mode: '0600'
+    remote_src: true
+  become: true


### PR DESCRIPTION
This PR adds support for Google Cloud Batch as a Galaxy job runner, with automatic NFS configuration and deployment orchestration. All GCP Batch-related functionality is controlled by the `enable_gcp_batch` variable and is completely optional.

**NOTE** Enabling GCP Batch in the playbook requires using a Galaxy Docker image with the Batch job runner included. EG `ksuderman/galaxy-min:25.1-batch-2`.

## Changes

### Role Configuration (`roles/galaxy_k8s_deployment/defaults/main.yml`)
- Added `enable_gcp_batch` flag (default: false)
- Added `gcp_batch_service_account_email` configuration
- Added `gcp_batch_region` configuration (default: "us-east4")
- Comprehensive documentation in comments

### Galaxy Application Tasks (`roles/galaxy_k8s_deployment/tasks/galaxy_application.yml`)
- **NFS LoadBalancer IP Detection**: Automatically detects NFS service LoadBalancer IP when GCP Batch is enabled
- **NFS Export Path Detection**: Uses `showmount` to auto-detect Galaxy PVC export path
- **Dynamic Helm Values**: Injects NFS server IP into job_conf.yml via Helm values merge
- **ConfigMap Updates**: Automatically updates job_conf.yml with detected NFS export path
- **Deployment Restarts**: Restarts Galaxy deployments to apply configuration changes
- All tasks are conditional on `enable_gcp_batch` flag

### NFS Setup Tasks (`roles/galaxy_k8s_deployment/tasks/nfs_setup.yml`)
- Patches NFS service for GCP Batch with internal LoadBalancer annotation
- Adds source IP restrictions (10.0.0.0/8) for security
- Only applies when `enable_gcp_batch=true`
