### PR TITLE
Add workflow to test deployments

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,119 @@
+# GitHub Workflows
+
+## Test Galaxy Deployment on GCE
+
+The `test-galaxy-gce.yml` workflow deploys Galaxy to a GCE VM and tests that the API is responsive.
+
+### Setup Requirements
+
+This workflow uses GCP Workload Identity Federation for authentication. You need to configure the following:
+
+#### 1. Create a Workload Identity Pool and Provider
+
+```bash
+# Set your project ID
+PROJECT_ID="your-project-id"
+PROJECT_NUMBER=$(gcloud projects describe $PROJECT_ID --format='value(projectNumber)')
+
+# Create Workload Identity Pool
+gcloud iam workload-identity-pools create "github-actions" \
+  --project="${PROJECT_ID}" \
+  --location="global" \
+  --display-name="GitHub Actions Pool"
+
+# Create Workload Identity Provider
+gcloud iam workload-identity-pools providers create-oidc "github-provider" \
+  --project="${PROJECT_ID}" \
+  --location="global" \
+  --workload-identity-pool="github-actions" \
+  --display-name="GitHub Provider" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.actor=assertion.actor,attribute.repository=assertion.repository" \
+  --issuer-uri="https://token.actions.githubusercontent.com"
+```
+
+#### 2. Create a Service Account
+
+```bash
+# Create service account
+gcloud iam service-accounts create github-actions-galaxy \
+  --project="${PROJECT_ID}" \
+  --display-name="GitHub Actions for Galaxy Testing"
+
+# Grant necessary permissions
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:github-actions-galaxy@${PROJECT_ID}.iam.gserviceaccount.com" \
+  --role="roles/compute.instanceAdmin.v1"
+
+gcloud projects add-iam-policy-binding $PROJECT_ID \
+  --member="serviceAccount:github-actions-galaxy@${PROJECT_ID}.iam.gserviceaccount.com" \
+  --role="roles/iam.serviceAccountUser"
+```
+
+#### 3. Configure Workload Identity Binding
+
+```bash
+# Replace with your GitHub repository
+REPO="your-github-org/galaxy-k8s-boot"
+
+# Allow GitHub Actions from your repository to impersonate the service account
+gcloud iam service-accounts add-iam-policy-binding \
+  "github-actions-galaxy@${PROJECT_ID}.iam.gserviceaccount.com" \
+  --project="${PROJECT_ID}" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github-actions/attribute.repository/${REPO}"
+```
+
+#### 4. Get the Workload Identity Provider Name
+
+```bash
+gcloud iam workload-identity-pools providers describe "github-provider" \
+  --project="${PROJECT_ID}" \
+  --location="global" \
+  --workload-identity-pool="github-actions" \
+  --format="value(name)"
+```
+
+This will output something like:
+```
+projects/123456789/locations/global/workloadIdentityPools/github-actions/providers/github-provider
+```
+
+#### 5. Configure GitHub Secrets
+
+Add the following secrets to your GitHub repository:
+
+- `GCP_WORKLOAD_IDENTITY_PROVIDER`: The full provider name from step 4
+- `GCP_SERVICE_ACCOUNT`: The service account email (e.g., `github-actions-galaxy@PROJECT_ID.iam.gserviceaccount.com`)
+
+### Running the Workflow
+
+1. Go to Actions tab in your GitHub repository
+2. Select "Test Galaxy Deployment on GCE" workflow
+3. Click "Run workflow"
+4. Customize parameters as needed:
+   - **galaxy-chart-version**: Galaxy Helm chart version (default: 6.6.0)
+   - **git-repo**: Repository URL for galaxy-k8s-boot
+   - **git-branch**: Branch to deploy
+   - **instance-name**: Name for the test VM
+   - **gcp-project**: GCP project ID
+   - **gcp-zone**: GCP zone
+
+### What the Workflow Does
+
+1. Authenticates to GCP using Workload Identity
+2. Generates an SSH key pair for the VM
+3. Launches a GCE VM using `bin/launch_vm.sh`
+4. Waits for cloud-init to complete
+5. Copies the kubeconfig from the VM
+6. Waits for all Galaxy deployments to rollout (15 minute timeout)
+7. Tests the `/api/version` endpoint
+8. Validates the response is valid JSON
+9. Deletes the VM (always runs, even on failure)
+
+### Troubleshooting
+
+If the workflow fails:
+- Check the workflow logs for detailed error messages
+- Verify Workload Identity is configured correctly
+- Ensure the service account has necessary permissions
+- Check GCP quotas for compute instances

--- a/.github/workflows/test-galaxy-gce.yml
+++ b/.github/workflows/test-galaxy-gce.yml
@@ -1,0 +1,191 @@
+name: Test Galaxy Deployment on GCE
+
+on:
+  workflow_dispatch:
+    inputs:
+      galaxy-chart-version:
+        description: 'Galaxy Helm chart version'
+        default: '6.6.0'
+        required: true
+      git-repo:
+        description: 'Git repository URL for galaxy-k8s-boot'
+        default: 'https://github.com/galaxyproject/galaxy-k8s-boot.git'
+        required: true
+      git-branch:
+        description: 'Git branch to deploy'
+        default: 'master'
+        required: true
+      instance-name:
+        description: 'Name for the test VM instance'
+        default: 'galaxy-test-ci'
+        required: true
+      gcp-project:
+        description: 'GCP project ID'
+        default: 'anvil-and-terra-development'
+        required: true
+      gcp-zone:
+        description: 'GCP zone'
+        default: 'us-east4-c'
+        required: true
+
+env:
+  INSTANCE_NAME: ${{ inputs.instance-name }}
+  GCP_PROJECT: ${{ inputs.gcp-project }}
+  GCP_ZONE: ${{ inputs.gcp-zone }}
+
+jobs:
+  test-galaxy:
+    name: Deploy and Test Galaxy
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write  # Required for Workload Identity
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Generate SSH key for VM
+        id: ssh-key
+        run: |
+          ssh-keygen -t rsa -b 4096 -f ~/.ssh/galaxy-ci-key -N "" -C "github-actions"
+          echo "public-key=$(cat ~/.ssh/galaxy-ci-key.pub)" >> $GITHUB_OUTPUT
+          echo "private-key-path=$HOME/.ssh/galaxy-ci-key" >> $GITHUB_OUTPUT
+
+      - name: Launch Galaxy VM
+        id: launch-vm
+        run: |
+          bin/launch_vm.sh \
+            --project "${{ env.GCP_PROJECT }}" \
+            --zone "${{ env.GCP_ZONE }}" \
+            --ephemeral-only \
+            --galaxy-chart-version "${{ inputs.galaxy-chart-version }}" \
+            --git-repo "${{ inputs.git-repo }}" \
+            --git-branch "${{ inputs.git-branch }}" \
+            -k "${{ steps.ssh-key.outputs.public-key }}" \
+            -f values/values.yml \
+            "${{ env.INSTANCE_NAME }}"
+
+      - name: Get VM IP address
+        id: vm-ip
+        run: |
+          sleep 10  # Give VM time to fully initialize
+          VM_IP=$(gcloud compute instances describe "${{ env.INSTANCE_NAME }}" \
+            --project="${{ env.GCP_PROJECT }}" \
+            --zone="${{ env.GCP_ZONE }}" \
+            --format='get(networkInterfaces[0].accessConfigs[0].natIP)')
+          echo "ip=${VM_IP}" >> $GITHUB_OUTPUT
+          echo "Galaxy VM IP: ${VM_IP}"
+
+      - name: Wait for cloud-init to complete
+        run: |
+          echo "Waiting for cloud-init to complete on ${{ steps.vm-ip.outputs.ip }}..."
+          for i in {1..60}; do
+            if gcloud compute ssh "${{ env.INSTANCE_NAME }}" \
+              --project="${{ env.GCP_PROJECT }}" \
+              --zone="${{ env.GCP_ZONE }}" \
+              --ssh-key-file="${{ steps.ssh-key.outputs.private-key-path }}" \
+              --command="cloud-init status --wait" 2>/dev/null; then
+              echo "Cloud-init completed successfully"
+              break
+            fi
+            echo "Attempt $i/60: Cloud-init still running or SSH not ready..."
+            sleep 30
+          done
+
+      - name: Copy kubeconfig from VM
+        run: |
+          mkdir -p ~/.kube
+          gcloud compute scp \
+            --project="${{ env.GCP_PROJECT }}" \
+            --zone="${{ env.GCP_ZONE }}" \
+            --ssh-key-file="${{ steps.ssh-key.outputs.private-key-path }}" \
+            "ubuntu@${{ env.INSTANCE_NAME }}:/home/ubuntu/.kube/config" \
+            ~/.kube/config
+
+          # Update kubeconfig to use external IP
+          sed -i "s|https://0.0.0.0:6443|https://${{ steps.vm-ip.outputs.ip }}:6443|" ~/.kube/config
+
+      - name: Wait for Galaxy deployments to rollout
+        run: |
+          echo "Waiting for Galaxy deployments to complete (timeout: 15 minutes)..."
+
+          # Get all deployments in the galaxy namespace
+          DEPLOYMENTS=$(kubectl get deployments -n galaxy -o jsonpath='{.items[*].metadata.name}')
+
+          if [ -z "$DEPLOYMENTS" ]; then
+            echo "No deployments found in galaxy namespace"
+            exit 1
+          fi
+
+          echo "Found deployments: $DEPLOYMENTS"
+
+          # Wait for each deployment to rollout
+          for deployment in $DEPLOYMENTS; do
+            echo "Waiting for deployment: $deployment"
+            kubectl rollout status deployment/$deployment -n galaxy --timeout=15m
+          done
+
+          echo "All deployments rolled out successfully"
+
+      - name: Test Galaxy API endpoint
+        id: test-api
+        run: |
+          GALAXY_URL="http://${{ steps.vm-ip.outputs.ip }}/api/version"
+          echo "Testing Galaxy API at: $GALAXY_URL"
+
+          # Wait for Galaxy to be responsive (max 5 minutes)
+          for i in {1..30}; do
+            if response=$(curl -s -f "$GALAXY_URL"); then
+              echo "Galaxy API is responsive"
+              echo "$response" | jq .
+
+              # Validate that response is valid JSON
+              if echo "$response" | jq -e . >/dev/null 2>&1; then
+                echo "Response is valid JSON ✓"
+                echo "version-info=$response" >> $GITHUB_OUTPUT
+                exit 0
+              else
+                echo "Response is not valid JSON"
+                exit 1
+              fi
+            fi
+            echo "Attempt $i/30: Galaxy not ready yet..."
+            sleep 10
+          done
+
+          echo "Galaxy API did not become responsive in time"
+          exit 1
+
+      - name: Cleanup - Delete VM
+        if: always()
+        run: |
+          echo "Cleaning up: Deleting VM ${{ env.INSTANCE_NAME }}"
+          gcloud compute instances delete "${{ env.INSTANCE_NAME }}" \
+            --project="${{ env.GCP_PROJECT }}" \
+            --zone="${{ env.GCP_ZONE }}" \
+            --quiet || echo "Failed to delete VM (may not exist)"
+
+      - name: Display test results
+        if: always()
+        run: |
+          echo "=== Test Results ==="
+          echo "Instance: ${{ env.INSTANCE_NAME }}"
+          echo "IP: ${{ steps.vm-ip.outputs.ip }}"
+          echo "Galaxy Chart Version: ${{ inputs.galaxy-chart-version }}"
+          echo "Git Repo: ${{ inputs.git-repo }}"
+          echo "Git Branch: ${{ inputs.git-branch }}"
+          if [ -n "${{ steps.test-api.outputs.version-info }}" ]; then
+            echo "Galaxy Version Info:"
+            echo "${{ steps.test-api.outputs.version-info }}" | jq .
+          fi


### PR DESCRIPTION
Currently the workflow can only be triggered by the `workflow_dispatch` event, but in the future it will be used in a full CI/CD pipeline.
