### PR TITLE
Remove deprecated single values file support

### DIFF
--- a/roles/galaxy_k8s_deployment/README.md
+++ b/roles/galaxy_k8s_deployment/README.md
@@ -111,7 +111,8 @@ ingress_version: "4.13.2"                  # NGINX ingress chart version
 galaxy_chart: cloudve/galaxy
 galaxy_chart_version: "6.5.0"              # Galaxy chart version
 galaxy_deps_version: "1.1.1"               # Galaxy dependencies version
-galaxy_values_file: "values/values.yml"    # Path to Galaxy values file
+galaxy_values_files:                       # List of Galaxy Helm values files
+  - "values/values.yml"
 galaxy_persistence_size: "20Gi"            # Galaxy data volume size
 galaxy_db_password: "galaxydbpassword"     # PostgreSQL password
 galaxy_user: "admin@galaxy.org"            # Galaxy admin user

--- a/roles/galaxy_k8s_deployment/defaults/main.yml
+++ b/roles/galaxy_k8s_deployment/defaults/main.yml
@@ -61,11 +61,9 @@ galaxy_chart_version: "6.6.0"
 galaxy_deps_version: "1.1.1"
 
 # Galaxy Helm values files configuration
-# Supports both single file (string, deprecated) and multiple files (list)
-# Examples:
-#   galaxy_values_file: "values/values.yml"  # Single file (backward compatible)
-#   galaxy_values_files: ["values/values.yml", "values/custom.yml"]  # Multiple files
-galaxy_values_file: ""  # Deprecated - use galaxy_values_files instead
+# Specify one or more values files to customize the Galaxy deployment
+# Files are applied in order - later files override earlier ones
+# Example: ["values/values.yml", "values/batch.yml", "values/custom.yml"]
 galaxy_values_files:
   - "values/values.yml"
 

--- a/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
+++ b/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
@@ -76,17 +76,10 @@
     msg: "Using node internal IP for NFS: {{ nfs_server }} (accessible from GCP Batch VMs in same VPC)"
   when: enable_gcp_batch | default(false) | bool
 
-# Prepare values files list with backward compatibility
+# Prepare values files list
 - name: Prepare Galaxy values files list
   set_fact:
-    _galaxy_values_files: >-
-      {%- if galaxy_values_file is defined and galaxy_values_file != "" -%}
-        {{ [galaxy_values_file] }}
-      {%- elif galaxy_values_files is defined and galaxy_values_files | length > 0 -%}
-        {{ galaxy_values_files }}
-      {%- else -%}
-        {{ ['values/values.yml'] }}
-      {%- endif -%}
+    _galaxy_values_files: "{{ galaxy_values_files | default(['values/values.yml']) }}"
 
 - name: Display Galaxy values files being used
   debug:


### PR DESCRIPTION
Having the `galaxy_value_file` and `galaxy_values_files` just adds bloat to the playbooks. Users can use the same mechanism for supplying multiple files and just supply a single file to achieve the same result.  If no values files are specified on the command line the default `values/values.yml` will be used.

Closes #40 
