### PR TITLE
Fix NFS mounting

### DIFF
--- a/bin/launch_vm.sh
+++ b/bin/launch_vm.sh
@@ -308,6 +308,7 @@ cat >> "$TEMP_USER_DATA" << 'EOF'
     galaxy_persistence_size="${PV_SIZE}"
     galaxy_db_password="gxy-db-password"
     galaxy_user="dev@galaxyproject.org"
+    enable_gcp_batch=true
     INVEOF
 
     echo "[`date`] - NFS storage size for Galaxy: ${PV_SIZE}"

--- a/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
+++ b/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
@@ -76,6 +76,13 @@
     msg: "Using node internal IP for NFS: {{ nfs_server }} (accessible from GCP Batch VMs in same VPC)"
   when: enable_gcp_batch | default(false) | bool
 
+- name: Fail if NFS server IP not determined
+  fail:
+    msg: "Could not determine NFS server IP. ansible_default_ipv4.address = {{ ansible_default_ipv4.address | default('undefined') }}"
+  when:
+    - enable_gcp_batch | default(false) | bool
+    - nfs_server is not defined or nfs_server == ""
+
 # Prepare values files list with backward compatibility
 - name: Prepare Galaxy values files list
   set_fact:
@@ -154,13 +161,11 @@
     wait_timeout: 300
   when: enable_gcp_batch | default(false) | bool
 
-- name: Detect NFS export path for Galaxy PVC
+- name: Detect NFS export path for Galaxy PVC from PersistentVolume
   shell: |
-    # Wait a moment for NFS export to be available
-    sleep 10
-
-    # Get NFS exports and find the PVC export path
-    showmount -e {{ nfs_server }} | grep '/export/pvc-' | head -1 | awk '{print $1}'
+    kubectl get pv -o jsonpath='{range .items[*]}{.spec.claimRef.name}{"\t"}{.spec.nfs.path}{"\n"}{end}' | grep galaxy-galaxy-pvc | awk '{print $2}'
+  environment:
+    KUBECONFIG: "{{ kubeconfig_path }}"
   register: nfs_export_detection
   retries: 10
   delay: 5
@@ -202,7 +207,19 @@
   register: galaxy_configs
   when: enable_gcp_batch | default(false) | bool
 
-- name: Update job_conf.yml with NFS export path
+- name: Display NFS configuration to be applied
+  debug:
+    msg: |
+      Updating Galaxy job_conf.yml with GCP Batch NFS settings:
+        nfs_server: {{ nfs_server }}
+        nfs_path: {{ nfs_export_path }}
+        nfs_mount_path: /galaxy/server/database
+  when:
+    - enable_gcp_batch | default(false) | bool
+    - nfs_export_path is defined
+    - nfs_server is defined
+
+- name: Update job_conf.yml with NFS server and export path
   kubernetes.core.k8s:
     state: present
     kubeconfig: "{{ kubeconfig_path }}"
@@ -212,10 +229,29 @@
       metadata:
         name: galaxy-configs
         namespace: galaxy
-      data: "{{ galaxy_configs.resources[0].data | combine({'job_conf.yml': (galaxy_configs.resources[0].data['job_conf.yml'] | from_yaml | combine({'runners': {'gcp_batch': {'nfs_path': nfs_export_path}}}, recursive=True) | to_nice_yaml) }) }}"
+      data: "{{ galaxy_configs.resources[0].data | combine({'job_conf.yml': (galaxy_configs.resources[0].data['job_conf.yml'] | from_yaml | combine({'runners': {'gcp_batch': {'nfs_server': nfs_server, 'nfs_path': nfs_export_path}}}, recursive=True) | to_nice_yaml) }) }}"
   when:
     - enable_gcp_batch | default(false) | bool
     - nfs_export_path is defined
+    - nfs_server is defined
+
+- name: Verify NFS configuration was applied
+  shell: |
+    kubectl get configmap galaxy-configs -n galaxy -o jsonpath='{.data.job_conf\.yml}' | grep -E 'nfs_server|nfs_path'
+  environment:
+    KUBECONFIG: "{{ kubeconfig_path }}"
+  register: nfs_config_verify
+  when:
+    - enable_gcp_batch | default(false) | bool
+    - nfs_export_path is defined
+
+- name: Display verified NFS configuration
+  debug:
+    msg: "Verified NFS config in ConfigMap:\n{{ nfs_config_verify.stdout }}"
+  when:
+    - enable_gcp_batch | default(false) | bool
+    - nfs_config_verify is defined
+    - nfs_config_verify.stdout is defined
 
 - name: Restart Galaxy deployments to pick up configuration changes
   shell: kubectl rollout restart deployment {{ item }} -n galaxy

--- a/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
+++ b/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
@@ -83,17 +83,9 @@
     - enable_gcp_batch | default(false) | bool
     - nfs_server is not defined or nfs_server == ""
 
-# Prepare values files list with backward compatibility
 - name: Prepare Galaxy values files list
   set_fact:
-    _galaxy_values_files: >-
-      {%- if galaxy_values_file is defined and galaxy_values_file != "" -%}
-        {{ [galaxy_values_file] }}
-      {%- elif galaxy_values_files is defined and galaxy_values_files | length > 0 -%}
-        {{ galaxy_values_files }}
-      {%- else -%}
-        {{ ['values/values.yml'] }}
-      {%- endif -%}
+    _galaxy_values_files: "{{ galaxy_values_files | default(['values/values.yml']) }}"
 
 - name: Display Galaxy values files being used
   debug:
@@ -147,18 +139,15 @@
 # ============================================================================
 # GCP Batch: NFS Export Path Detection
 # ============================================================================
-- name: Wait for Galaxy PVC to be created
-  kubernetes.core.k8s_info:
-    api_version: v1
-    kind: PersistentVolumeClaim
-    name: galaxy-galaxy-pvc
-    namespace: galaxy
-    kubeconfig: "{{ kubeconfig_path }}"
-    wait: true
-    wait_condition:
-      type: Bound
-      status: "True"
-    wait_timeout: 300
+- name: Wait for Galaxy PVC to be bound
+  shell: |
+    kubectl get pvc galaxy-galaxy-pvc -n galaxy -o jsonpath='{.status.phase}'
+  environment:
+    KUBECONFIG: "{{ kubeconfig_path }}"
+  register: pvc_status
+  retries: 60
+  delay: 10
+  until: pvc_status.stdout == "Bound"
   when: enable_gcp_batch | default(false) | bool
 
 - name: Detect NFS export path for Galaxy PVC from PersistentVolume
@@ -174,11 +163,11 @@
 
 - name: Set NFS export path for Galaxy database
   set_fact:
-    nfs_export_path: "{{ nfs_export_detection.stdout }}"
+    nfs_export_path: "{{ nfs_export_detection.stdout | trim }}"
   when:
     - enable_gcp_batch | default(false) | bool
     - nfs_export_detection.stdout is defined
-    - nfs_export_detection.stdout != ""
+    - nfs_export_detection.stdout | trim != ""
 
 - name: Display detected NFS export path
   debug:
@@ -195,22 +184,15 @@
     - nfs_export_path is not defined or nfs_export_path == ""
 
 # ============================================================================
-# GCP Batch: Update Configuration and Restart
+# GCP Batch: Update Configuration with Helm Upgrade
 # ============================================================================
-- name: Get current job_conf.yml from ConfigMap
-  kubernetes.core.k8s_info:
-    api_version: v1
-    kind: ConfigMap
-    name: galaxy-configs
-    namespace: galaxy
-    kubeconfig: "{{ kubeconfig_path }}"
-  register: galaxy_configs
-  when: enable_gcp_batch | default(false) | bool
+# Use Helm upgrade to properly update the ConfigMap with the detected NFS path.
+# This is more reliable than patching the ConfigMap directly.
 
 - name: Display NFS configuration to be applied
   debug:
     msg: |
-      Updating Galaxy job_conf.yml with GCP Batch NFS settings:
+      Upgrading Galaxy Helm release with GCP Batch NFS settings:
         nfs_server: {{ nfs_server }}
         nfs_path: {{ nfs_export_path }}
         nfs_mount_path: /galaxy/server/database
@@ -219,17 +201,41 @@
     - nfs_export_path is defined
     - nfs_server is defined
 
-- name: Update job_conf.yml with NFS server and export path
-  kubernetes.core.k8s:
-    state: present
+- name: Helm upgrade Galaxy with detected NFS export path
+  kubernetes.core.helm:
+    name: galaxy
+    namespace: galaxy
+    chart_ref: "{{ galaxy_chart }}"
+    chart_version: "{{ galaxy_chart_version }}"
     kubeconfig: "{{ kubeconfig_path }}"
-    definition:
-      apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: galaxy-configs
-        namespace: galaxy
-      data: "{{ galaxy_configs.resources[0].data | combine({'job_conf.yml': (galaxy_configs.resources[0].data['job_conf.yml'] | from_yaml | combine({'runners': {'gcp_batch': {'nfs_server': nfs_server, 'nfs_path': nfs_export_path}}}, recursive=True) | to_nice_yaml) }) }}"
+    values_files: "{{ lookup('sequence', 'start=0 end=' ~ (_galaxy_values_files|length - 1) ~ ' format=/tmp/galaxy_values_%d.yml', wantlist=True) }}"
+    values: "{{ _helm_values_base | combine(_helm_values_gcp_batch_with_path, recursive=True) }}"
+  vars:
+    _helm_values_base:
+      persistence:
+        size: "{{ galaxy_persistence_size }}"
+      postgresql:
+        galaxyDatabasePassword: "{{ galaxy_db_password }}"
+      configs:
+        galaxy.yml:
+          galaxy:
+            single_user: "{{ galaxy_user }}"
+            admin_users: "{{ galaxy_user }}"
+            master_api_key: "{{ galaxy_api_key | default(omit) }}"
+      jobs:
+        rules:
+          tpv_rules_local.yml:
+            destinations:
+              k8s:
+                max_cores: "{{ galaxy_job_max_cores }}"
+                max_mem: "{{ galaxy_job_max_mem }}"
+    _helm_values_gcp_batch_with_path:
+      configs:
+        job_conf.yml:
+          runners:
+            gcp_batch:
+              nfs_server: "{{ nfs_server }}"
+              nfs_path: "{{ nfs_export_path }}"
   when:
     - enable_gcp_batch | default(false) | bool
     - nfs_export_path is defined
@@ -252,15 +258,3 @@
     - enable_gcp_batch | default(false) | bool
     - nfs_config_verify is defined
     - nfs_config_verify.stdout is defined
-
-- name: Restart Galaxy deployments to pick up configuration changes
-  shell: kubectl rollout restart deployment {{ item }} -n galaxy
-  environment:
-    KUBECONFIG: "{{ kubeconfig_path }}"
-  loop:
-    - galaxy-web
-    - galaxy-workflow
-    - galaxy-job-0
-  when:
-    - enable_gcp_batch | default(false) | bool
-    - nfs_export_path is defined

--- a/values/api-key.yml
+++ b/values/api-key.yml
@@ -1,0 +1,4 @@
+configs:
+  galaxy.yml:
+    galaxy:
+      master_api_key: galaxypassword

--- a/values/probes.yml
+++ b/values/probes.yml
@@ -1,0 +1,7 @@
+webHandlers:
+  startupProbe:
+    enabled: true
+    initialDelaySeconds: 120
+    periodSeconds: 30
+    failureThreshold: 50
+    timeoutSeconds: 5

--- a/values/v25.1-batch.yml
+++ b/values/v25.1-batch.yml
@@ -1,3 +1,3 @@
 image:
   repository: ksuderman/galaxy-min
-  tag: "25.1-batch-2"
+  tag: "25.1-batch-3"

--- a/values/v26.0-dev.yml
+++ b/values/v26.0-dev.yml
@@ -1,0 +1,3 @@
+image:
+  repository: ksuderman/galaxy-min
+  tag: "26.0-dev"


### PR DESCRIPTION
Improves the way the NFS IP address and PV mount directory are detected. 

Also adds the runtime flag `-g`, `--enable-gcp-batch` to the `bin/launch_vm.sh` script to control whether the playbook will configure NFS to enable the GCP Batch job runner.  

**NOTE** if `--enable-gcp-batch` is specified the the user ***must*** also specify a Galaxy Docker image that include the GCP Batch job runner.

Closes #41 
