### PR TITLE
Add direct GCP Batch runner support

### DIFF
--- a/bin/launch_vm.sh
+++ b/bin/launch_vm.sh
@@ -399,7 +399,7 @@ cat >> "$TEMP_USER_DATA" << 'EOF'
     echo "[`date`] - Galaxy Values Files: ${GALAXY_VALUES_FILES_JSON}"
     echo "[`date`] - Inventory file created at /tmp/ansible-inventory/localhost; running ansible-pull..."
 
-    ANSIBLE_CALLBACKS_ENABLED=profile_tasks ANSIBLE_HOST_PATTERN_MISMATCH=ignore ansible-pull -U ${GIT_REPO} -C ${GIT_BRANCH} -d /home/ubuntu/ansible -i /tmp/ansible-inventory/localhost --accept-host-key --limit 127.0.0.1 --extra-vars "{\"galaxy_chart_version\": \"${GALAXY_CHART_VERSION}\", \"galaxy_deps_version\": \"${GALAXY_DEPS_VERSION}\", \"galaxy_values_files\": ${GALAXY_VALUES_FILES_JSON}}" playbook.yml
+    ANSIBLE_CALLBACKS_ENABLED=profile_tasks ANSIBLE_HOST_PATTERN_MISMATCH=ignore ansible-pull -U ${GIT_REPO} -C ${GIT_BRANCH} -d /home/ubuntu/ansible -i /tmp/ansible-inventory/localhost --accept-host-key --limit 127.0.0.1 --extra-vars "{\"enable_gcp_batch\": true, \"galaxy_chart_version\": \"${GALAXY_CHART_VERSION}\", \"galaxy_deps_version\": \"${GALAXY_DEPS_VERSION}\", \"galaxy_values_files\": ${GALAXY_VALUES_FILES_JSON}}" playbook.yml
 
     echo "[`date`] - User data script completed."
     '

--- a/roles/galaxy_k8s_deployment/defaults/main.yml
+++ b/roles/galaxy_k8s_deployment/defaults/main.yml
@@ -110,7 +110,7 @@ galaxy_job_max_mem: 4
 #   - Auto-detect NFS export path for Galaxy PVC
 #   - Update job_conf.yml with GCP Batch runner configuration
 #   - Restart Galaxy deployments to apply changes
-enable_gcp_batch: false
+enable_gcp_batch: true
 gcp_batch_service_account_email: ""
 gcp_batch_region: "us-east4"
 

--- a/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
+++ b/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
@@ -299,18 +299,17 @@
 # ============================================================================
 # GCP Batch: NFS Export Path Detection
 # ============================================================================
-- name: Wait for Galaxy PVC to be created
+- name: Wait for Galaxy PVC to be bound
   kubernetes.core.k8s_info:
     api_version: v1
     kind: PersistentVolumeClaim
     name: galaxy-galaxy-pvc
     namespace: galaxy
     kubeconfig: "{{ kubeconfig_path }}"
-    wait: true
-    wait_condition:
-      type: Bound
-      status: "True"
-    wait_timeout: 300
+  register: galaxy_pvc
+  until: galaxy_pvc.resources | length > 0 and galaxy_pvc.resources[0].status.phase == "Bound"
+  retries: 30
+  delay: 10
   when: enable_gcp_batch | default(false) | bool
 
 - name: Detect NFS export path for Galaxy PVC

--- a/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
+++ b/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
@@ -289,12 +289,7 @@
               k8s:
                 max_cores: "{{ galaxy_job_max_cores }}"
                 max_mem: "{{ galaxy_job_max_mem }}"
-    _helm_values_gcp_batch:
-      configs:
-        job_conf.yml:
-          runners:
-            gcp_batch:
-              nfs_server: "{{ nfs_server }}"
+    _helm_values_gcp_batch: {}
     _helm_values_cnpg_plugin:
       postgresql:
         cluster:
@@ -366,7 +361,7 @@
   register: galaxy_configs
   when: enable_gcp_batch | default(false) | bool
 
-- name: Update job_conf.yml with NFS export path
+- name: Update job_conf.yml with gcp_batch_volumes for NFS access
   kubernetes.core.k8s:
     state: present
     kubeconfig: "{{ kubeconfig_path }}"
@@ -376,7 +371,8 @@
       metadata:
         name: galaxy-configs
         namespace: galaxy
-      data: "{{ galaxy_configs.resources[0].data | combine({'job_conf.yml': (galaxy_configs.resources[0].data['job_conf.yml'] | from_yaml | combine({'runners': {'gcp_batch': {'nfs_path': nfs_export_path}}}, recursive=True) | to_nice_yaml) }) }}"
+      # gcp_batch_volumes format: "server:/remote_path:/mount_path"
+      data: "{{ galaxy_configs.resources[0].data | combine({'job_conf.yml': (galaxy_configs.resources[0].data['job_conf.yml'] | from_yaml | combine({'runners': {'gcp_batch': {'gcp_batch_volumes': nfs_server ~ ':' ~ nfs_export_path ~ ':/galaxy/server/database'}}}, recursive=True) | to_nice_yaml) }) }}"
   when:
     - enable_gcp_batch | default(false) | bool
     - nfs_export_path is defined

--- a/values/batch.yml
+++ b/values/batch.yml
@@ -1,3 +1,9 @@
+# Increase startup probe timeout to allow for CVMFS tool loading
+web:
+  startupProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    failureThreshold: 120  # Allow up to ~20 minutes
 
 configs:
   job_conf.yml:
@@ -11,10 +17,9 @@ configs:
 #        service_account_file: /etc/secrets/galaxy/key.json
         service_account_email: galaxy-batch-runner@anvil-and-terra-development.iam.gserviceaccount.com
 
-        # NFS configuration (required)
-        # nfs_server is set dynamically by the playbook via helm_values_gcp_batch
-        nfs_path: /             # Root path on NFS server. This will be updated by the playbook.
-        nfs_mount_path: /galaxy/server/database # Mount point in Batch VMs
+        # NFS/Volume configuration (required)
+        # Format: "server:/remote_path:/mount_path" - set dynamically by playbook via ConfigMap update
+        # gcp_batch_volumes: "NFS_SERVER_IP:/export/pvc-xxx:/galaxy/server/database"
 
         # Network configuration (required for NFS access)
         network: default
@@ -29,13 +34,14 @@ configs:
 
         # Container settings
         use_container: true
-        container_image: ksuderman/galaxy-min:25.1-batch-2  # fallback if tool doesn't specify
+        # Note: container_image comes from tool requirements via Galaxy's container finder
         galaxy_user_id: 10001
         galaxy_group_id: 10001
+        docker_extra_volumes: "/cvmfs/data.galaxyproject.org:/cvmfs/data.galaxyproject.org:ro,/cvmfs/cloud.galaxyproject.org:/cvmfs/cloud.galaxyproject.org:ro"
 
         # Custom VM image with CVMFS pre-configured (update date as needed)
 #        custom_vm_image: projects/anvil-and-terra-development/global/images/galaxy-k8s-boot-v2025-09-26
-        custom_vm_image: projects/anvil-and-terra-development/global/images/galaxy-batch-debian12-20251118
+        custom_vm_image: projects/anvil-and-terra-development/global/images/galaxy-k8s-boot-v2026-01-24
         # Job execution settings
         max_retry_count: 3
         max_run_duration: 3600s
@@ -47,9 +53,6 @@ configs:
           runner: local
         gcp_batch:
           runner: gcp_batch
-          # Override runner parameters if needed
-          container_image: ubuntu:20.04
-          machine_type: e2-standard-4
     destinations:
       - id: gcp_batch_default
         runner: gcp_batch

--- a/values/v26.0.yml
+++ b/values/v26.0.yml
@@ -1,0 +1,4 @@
+# Galaxy 26.0 RC
+image:
+  repository: ksuderman/galaxy-min
+  tag: "26.0.rc1"


### PR DESCRIPTION
## Add direct GCP Batch runner support

Minimal changes on top of `upstream/dev` to update the direct GCP Batch job runner configuration.

### Changes

**`values/batch.yml`**
- Added startup probe timeout to allow for CVMFS tool loading (~20 min)
- Replaced `nfs_path`/`nfs_mount_path`/`nfs_server` with `gcp_batch_volumes` (format: `server:/remote_path:/mount_path`, set dynamically by playbook via ConfigMap)
- Removed hardcoded `container_image` fallback — container image now comes from tool requirements via Galaxy's container finder
- Added `docker_extra_volumes` for CVMFS mounts (`data.galaxyproject.org`, `cloud.galaxyproject.org`)
- Updated `custom_vm_image` to `galaxy-k8s-boot-v2026-01-24`
- Removed `container_image` and `machine_type` overrides from gcp_batch environment

**`galaxy_application.yml`**
- ConfigMap patch now sets `gcp_batch_volumes` (combined `server:path:mount`) instead of `nfs_path`
- Removed unused `_helm_values_gcp_batch` that passed `nfs_server` via Helm values (no longer needed since volume config is set post-deploy via ConfigMap)
