### PR TITLE
max_run_duration must be in seconds

### DIFF
--- a/values/values.yml
+++ b/values/values.yml
@@ -89,7 +89,8 @@ configs:
         custom_vm_image: projects/anvil-and-terra-development/global/images/galaxy-k8s-boot-debian12-v2026-02-24
         # Job execution settings
         max_retry_count: 3
-        max_run_duration: 8h
+        # Max time a job will run before being deleted. Must be in seconds (end with 's'). Default 24hrs.
+        max_run_duration: 86400s
         polling_interval: 30
       local:
         load: galaxy.jobs.runners.local:LocalJobRunner


### PR DESCRIPTION
Seconds seems to be the only value accepted (although I cannot find docs saying that). With value of `8h`, Galaxy job errored with:
```
Failed to submit job to Google Cloud Batch: Duration must end with letter "s": 8h.
```