### PR TITLE
Add Galaxy pod usage monitoring app

### DIFF
--- a/roles/galaxy_k8s_deployment/defaults/main.yml
+++ b/roles/galaxy_k8s_deployment/defaults/main.yml
@@ -10,6 +10,7 @@ setup_storage: true
 setup_ingress: true
 deploy_galaxy: true
 deploy_pulsar: false
+deploy_monitor: true
 
 # CVMFS Configuration (installed when setup_system is true)
 setup_cvmfs: true
@@ -129,3 +130,10 @@ pulsar_chart: cloudve/pulsar
 pulsar_chart_version: "0.2.0"
 pulsar_deps_version: "1.1.1"
 pulsar_api_key: ""
+
+# Galaxy K8s Monitor Configuration
+monitor_chart: cloudve/galaxy-k8s-monitor
+monitor_chart_version: "0.1.1"
+monitor_image: afgane/galaxy-k8s-monitor
+monitor_namespace: galaxy
+monitor_base_path: /monitor

--- a/roles/galaxy_k8s_deployment/tasks/main.yml
+++ b/roles/galaxy_k8s_deployment/tasks/main.yml
@@ -33,3 +33,7 @@
 - name: Include Pulsar application setup tasks
   ansible.builtin.include_tasks: pulsar_application.yml
   when: deploy_pulsar | default(false)
+
+- name: Include Galaxy K8s Monitor setup tasks
+  ansible.builtin.include_tasks: monitor_application.yml
+  when: deploy_monitor | default(true)

--- a/roles/galaxy_k8s_deployment/tasks/monitor_application.yml
+++ b/roles/galaxy_k8s_deployment/tasks/monitor_application.yml
@@ -1,0 +1,24 @@
+---
+# Galaxy K8s Monitor Application Setup Tasks
+- name: Helm install galaxy-k8s-monitor
+  kubernetes.core.helm:
+    name: galaxy-k8s-monitor
+    namespace: "{{ monitor_namespace }}"
+    chart_ref: "{{ monitor_chart }}"
+    chart_version: "{{ monitor_chart_version }}"
+    kubeconfig: "{{ kubeconfig_path }}"
+    values:
+      ingress:
+        enabled: true
+        className: nginx
+        hosts:
+          - host: ""
+            paths:
+              - path: "{{ monitor_base_path }}"
+                pathType: ImplementationSpecific
+      monitor:
+        image:
+          repository: "{{ monitor_image }}"
+          tag: "latest"
+        namespace: "{{ monitor_namespace }}"
+        basePath: "{{ monitor_base_path }}"


### PR DESCRIPTION
Add a monitoring app [galaxy-k8s-monitor](https://github.com/galaxyproject/galaxy-k8s-monitor) that captures usage of Galaxy pods. The app is served at `/monitor` endpoint. 

<img width="1480" height="3464" alt="image" src="https://github.com/user-attachments/assets/89b8418c-c3ec-4d2a-bff1-6b764573d4ed" />
