### PR TITLE
Handle expression tools, parameter tools, and small jobs

### DIFF
--- a/bin/launch_vm.sh
+++ b/bin/launch_vm.sh
@@ -399,7 +399,7 @@ cat >> "$TEMP_USER_DATA" << 'EOF'
 
     mkdir -p /tmp/ansible-inventory
     cat > /tmp/ansible-inventory/localhost << INVEOF
-    [vm]
+    [vms]
     127.0.0.1 ansible_connection=local ansible_python_interpreter="/usr/bin/python3"
 
     [all:vars]

--- a/bin/user_data.sh
+++ b/bin/user_data.sh
@@ -110,7 +110,7 @@ write_files:
 
       mkdir -p /tmp/ansible-inventory
       cat > /tmp/ansible-inventory/localhost << EOF
-      [vm]
+      [vms]
       127.0.0.1 ansible_connection=local ansible_python_interpreter="/usr/bin/python3"
 
       [all:vars]

--- a/mixins/logo.yml
+++ b/mixins/logo.yml
@@ -1,0 +1,4 @@
+configs:
+  galaxy.yml:
+    galaxy:
+      logo_url: null

--- a/mixins/v26.0.yml
+++ b/mixins/v26.0.yml
@@ -1,4 +1,4 @@
-# Galaxy 26.0 RC
+# Galaxy 26.0.0
 image:
   repository: quay.io/galaxyproject/galaxy-min
-  tag: "26.0-auto"
+  tag: "26.0.0"

--- a/values/values.yml
+++ b/values/values.yml
@@ -92,7 +92,7 @@ configs:
         # Max time a job will run before being deleted. Must be in seconds (end with 's'). Default 24hrs.
         max_run_duration: 86400s
         polling_interval: 30
-        delete_completed_jobs: true
+        # delete_completed_jobs: true # Not available until 26.1 (is in v26.1-auto images)
       local:
         load: galaxy.jobs.runners.local:LocalJobRunner
         workers: 3

--- a/values/values.yml
+++ b/values/values.yml
@@ -92,6 +92,7 @@ configs:
         # Max time a job will run before being deleted. Must be in seconds (end with 's'). Default 24hrs.
         max_run_duration: 86400s
         polling_interval: 30
+        delete_completed_jobs: true
       local:
         load: galaxy.jobs.runners.local:LocalJobRunner
         workers: 3
@@ -135,6 +136,19 @@ configs:
         id: __IMPORT_WORKFLOW__
       - environment: local
         id: random_lines1
+      # Expression/param tools must run locally — TPV additive tag merge
+      # with the global DB causes reject:[local] to persist even when
+      # overridden, so route them here before TPV is consulted.
+      - environment: local
+        id: compose_text_param
+      - environment: local
+        id: map_param_value
+      - environment: local
+        id: param_value_from_file
+      - environment: local
+        id: tp_awk_tool
+      - environment: local
+        id: tp_grep_tool
     limits:
       - type: total_walltime
         window: 1  # number in days
@@ -144,12 +158,31 @@ jobs:
    rules:
     tpv_rules_local.yml:
       destinations:
+        k8s:
+          max_accepted_cores: 1
+          max_accepted_mem: 4
+          scheduling:
+            prefer:
+              - small-job
         gcp_batch:
           runner: gcp_batch
           params:
             docker_enabled: "true"
             cores: "{cores}"
             mem: "{mem}"
+            job_id_prefix: galaxy-batch
+      tools:
+        default:
+          scheduling:
+            prefer:
+              - small-job
+          rules:
+            - id: force_default_container_for_built_in_tools
+              if: |
+                from galaxy.tools import GALAXY_LIB_TOOLS_UNVERSIONED
+                tool.id in GALAXY_LIB_TOOLS_UNVERSIONED or "CONVERTER_" == tool.id[:10] or tool.is_datatype_converter
+              params:
+                docker_container_id_override: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
 
 extraVolumes:
   - name: static-images


### PR DESCRIPTION
The `job_conf.yml` and TPV rules need to send expression and parameter tools to the `local` job runner, jobs that require <1 core and <4G memory to the `k8s` runner, and the rest to the `gcp_batch` job runner.

Still needs testing.
