### PR TITLE
Update default post-install profile handling

### DIFF
--- a/bin/launch_vm.sh
+++ b/bin/launch_vm.sh
@@ -29,6 +29,8 @@ DRY_RUN=""
 POSTGRES_DISK_NAME=""
 EPHEMERAL_ONLY=false
 GALAXY_VALUES_FILES=()  # Array to hold multiple values files
+GALAXY_IMPORT_PROFILES=()  # Array to hold post-install import profile values files
+PROFILE_OVERRIDE=false  # Set true when --profile is supplied (overrides galaxy_import_profile)
 INSTANCE_NAME=""
 SSH_KEY=""
 
@@ -61,6 +63,9 @@ Options:
   --galaxy-deps-version VERSION     Galaxy dependencies chart version (default: $GALAXY_DEPS_VERSION)
   --postgres-disk DISK_NAME         Name of PostgreSQL disk (default: galaxy-postgres-INSTANCE_NAME)
   --postgres-disk-size SIZE         Size of PostgreSQL disk (default: $POSTGRES_DISK_SIZE)
+  --profile FILE                    Post-install import profile values file, overriding the
+                                    galaxy_import_profile role default (can be specified multiple
+                                    times). Use --profile '' to disable post-install imports.
   --restore-galaxy                  Auto-detect and restore Galaxy from existing data
   -h, --help, help                  Show this help message
 
@@ -89,6 +94,13 @@ Examples:
   # Launch VM with multiple Helm values files (order matters - later files override earlier ones)
   $0 -k "ssh-rsa AAAAB3..." -f values/values.yml -f mixins/v26.1.yml my-galaxy-vm
   $0 -k "ssh-rsa AAAAB3..." --values values/values.yml --values mixins/multiuser.yml --values mixins/admins.yml my-galaxy-vm
+
+  # Launch VM with a custom post-install import profile (overrides the default anvil profile)
+  $0 -k "ssh-rsa AAAAB3..." --profile mixins/postinstall.yml my-galaxy-vm
+
+  # Launch VM with post-install imports disabled
+  $0 -k "ssh-rsa AAAAB3..." --profile '' my-galaxy-vm
+
   # Launch VM with custom git repository and branch
   $0 -k "ssh-rsa AAAAB3..." -g "https://github.com/username/galaxy-k8s-boot.git" -b "feature-branch" my-galaxy-vm
 
@@ -123,6 +135,14 @@ while [[ $# -gt 0 ]]; do
             ;;
         -i|--machine-image)
             MACHINE_IMAGE="$2"
+            shift 2
+            ;;
+        --profile)
+            # Override galaxy_import_profile. An empty value disables imports ([]).
+            PROFILE_OVERRIDE=true
+            if [ -n "$2" ]; then
+                GALAXY_IMPORT_PROFILES+=("$2")
+            fi
             shift 2
             ;;
         --postgres-disk)
@@ -324,6 +344,19 @@ fi
 # Convert values files list to JSON array
 GALAXY_VALUES_FILES_JSON=$(echo "$GALAXY_VALUES_FILES_LIST" | sed -e 's/;/","/g' -e 's/^/["/' -e 's/$/"]/')
 
+# Build the galaxy_import_profile JSON array only when --profile was supplied.
+# An empty array ([]) disables post-install imports; if --profile is not used the
+# variable stays empty and the role's galaxy_import_profile default is left intact.
+GALAXY_IMPORT_PROFILE_JSON=""
+if [ "$PROFILE_OVERRIDE" = true ]; then
+    if [ ${#GALAXY_IMPORT_PROFILES[@]} -eq 0 ]; then
+        GALAXY_IMPORT_PROFILE_JSON="[]"
+    else
+        GALAXY_IMPORT_PROFILE_LIST=$(IFS=';'; echo "${GALAXY_IMPORT_PROFILES[*]}")
+        GALAXY_IMPORT_PROFILE_JSON=$(echo "$GALAXY_IMPORT_PROFILE_LIST" | sed -e 's/;/","/g' -e 's/^/["/' -e 's/$/"]/')
+    fi
+fi
+
 cat > "$TEMP_USER_DATA" << 'EOF'
 #cloud-config
 runcmd:
@@ -411,6 +444,7 @@ cat >> "$TEMP_USER_DATA" << EOF
     GALAXY_CHART_VERSION="${GALAXY_CHART_VERSION}"
     GALAXY_DEPS_VERSION="${GALAXY_DEPS_VERSION}"
     GALAXY_VALUES_FILES_JSON='${GALAXY_VALUES_FILES_JSON}'
+    GALAXY_IMPORT_PROFILE_JSON='${GALAXY_IMPORT_PROFILE_JSON}'
     RESTORE_GALAXY="${RESTORE_GALAXY}"
 EOF
 
@@ -441,9 +475,17 @@ cat >> "$TEMP_USER_DATA" << 'EOF'
     echo "[`date`] - Galaxy Chart Version: ${GALAXY_CHART_VERSION}"
     echo "[`date`] - Galaxy Deps Version: ${GALAXY_DEPS_VERSION}"
     echo "[`date`] - Galaxy Values Files: ${GALAXY_VALUES_FILES_JSON}"
+    echo "[`date`] - Galaxy Import Profile: ${GALAXY_IMPORT_PROFILE_JSON:-(role default)}"
     echo "[`date`] - Inventory file created at /tmp/ansible-inventory/localhost; running ansible-pull..."
 
-    ANSIBLE_CALLBACKS_ENABLED=profile_tasks ANSIBLE_HOST_PATTERN_MISMATCH=ignore ansible-pull -U ${GIT_REPO} -C ${GIT_BRANCH} -d /home/PLACEHOLDER_VM_USER/ansible -i /tmp/ansible-inventory/localhost --accept-host-key --limit 127.0.0.1 --extra-vars "{\"enable_gcp_batch\": true, \"galaxy_chart\": \"${GALAXY_CHART}\", \"galaxy_chart_version\": \"${GALAXY_CHART_VERSION}\", \"galaxy_deps_chart\": \"${GALAXY_DEPS_CHART}\", \"galaxy_deps_version\": \"${GALAXY_DEPS_VERSION}\", \"galaxy_values_files\": ${GALAXY_VALUES_FILES_JSON}}" playbook.yml
+    # Build the ansible-pull extra-vars, only overriding galaxy_import_profile when --profile was used.
+    EXTRA_VARS="{\"enable_gcp_batch\": true, \"galaxy_chart\": \"${GALAXY_CHART}\", \"galaxy_chart_version\": \"${GALAXY_CHART_VERSION}\", \"galaxy_deps_chart\": \"${GALAXY_DEPS_CHART}\", \"galaxy_deps_version\": \"${GALAXY_DEPS_VERSION}\", \"galaxy_values_files\": ${GALAXY_VALUES_FILES_JSON}"
+    if [ -n "${GALAXY_IMPORT_PROFILE_JSON}" ]; then
+        EXTRA_VARS="${EXTRA_VARS}, \"galaxy_import_profile\": ${GALAXY_IMPORT_PROFILE_JSON}"
+    fi
+    EXTRA_VARS="${EXTRA_VARS}}"
+
+    ANSIBLE_CALLBACKS_ENABLED=profile_tasks ANSIBLE_HOST_PATTERN_MISMATCH=ignore ansible-pull -U ${GIT_REPO} -C ${GIT_BRANCH} -d /home/PLACEHOLDER_VM_USER/ansible -i /tmp/ansible-inventory/localhost --accept-host-key --limit 127.0.0.1 --extra-vars "${EXTRA_VARS}" playbook.yml
 
     echo "[`date`] - User data script completed."
     '

--- a/mixins/postinstall.yml
+++ b/mixins/postinstall.yml
@@ -1,7 +1,7 @@
 postInstallJob:
   enabled: true
   image: quay.io/galaxyproject/abm:2.13.0
-  galaxyUser: "default-user@galaxyproject.org"
+  galaxyUser: "suderman@jhu.edu"
   bootstrapConfig: |
     version: 1
     # Workflow imports
@@ -13,29 +13,14 @@ postInstallJob:
       - "https://benchmarking-inputs.s3.amazonaws.com/ERR3485802/Galaxy-History-VC-Test-Data.tar.gz"
       - "https://benchmarking-inputs.s3.amazonaws.com/RNASeq/Galaxy-History-SRR24043307-downsampled-20.tar.gz"
     
-    # Creates a history named "Configured Datasets" for the datasets
-    datasets:
-      - "https://zenodo.org/record/1324070/files/wt_H3K4me3_read1.fastq.gz"
-      - "https://zenodo.org/record/1324070/files/wt_H3K4me3_read12.fastq.gz"
-
     # Organized dataset imports (creates named histories)
     datasets:
-      "RNA-seq Tutorial Data":
+      # Creates a history named "Configured Datasets" for the datasets
+      - "https://zenodo.org/record/1324070/files/wt_H3K4me3_read1.fastq.gz"
+      - "https://zenodo.org/record/1324070/files/wt_H3K4me3_read12.fastq.gz"
+      - "RNA-seq Tutorial Data":
         - "https://benchmarking-inputs.s3.amazonaws.com/SRR24043307/SRR24043307-1.fastq.gz"
         - "https://benchmarking-inputs.s3.amazonaws.com/SRR24043307/SRR24043307-2.fastq.gz"
-      "ChIP-Seq Input Data":
+      - "ChIP-Seq Input Data":
         - "https://zenodo.org/record/1324070/files/wt_H3K4me3_read1.fastq.gz"
         - "https://zenodo.org/record/1324070/files/wt_H3K4me3_read2.fastq.gz"
-
-    terra:
-      - namespace: "notebooks-canary-project"
-        workspace: "SArS-CoV-2-Genome copy"
-        datasets:
-          "Reference Data":
-            - pattern: "Tables/reference/SARS-CoV-2_reference_genome.fasta"
-              datatype: "fasta"
-          "Sample Data":
-            - pattern: "Tables/sample/VA_sample_forward_reads.fastq"
-              datatype: "fastqsanger"
-            - pattern: "Tables/sample/VA_sample_reverse_reads.fastq"
-              datatype: "fastqsanger"

--- a/mixins/postinstall.yml
+++ b/mixins/postinstall.yml
@@ -8,6 +8,7 @@ postInstallJob:
     workflows:
       - "https://raw.githubusercontent.com/galaxyproject/iwc/main/workflows/transcriptomics/rnaseq-pe/rnaseq-pe.ga"
       - "https://benchmarking-inputs.s3.amazonaws.com/Variant/Galaxy-Workflow-Variant_analysis_on_WGS_PE_data.ga"
+    
     # History imports (exported Galaxy histories)
     histories:
       - "https://benchmarking-inputs.s3.amazonaws.com/ERR3485802/Galaxy-History-VC-Test-Data.tar.gz"
@@ -15,12 +16,12 @@ postInstallJob:
     
     # Organized dataset imports (creates named histories)
     datasets:
-      # Creates a history named "Configured Datasets" for the datasets
-      - "https://zenodo.org/record/1324070/files/wt_H3K4me3_read1.fastq.gz"
-      - "https://zenodo.org/record/1324070/files/wt_H3K4me3_read12.fastq.gz"
-      - "RNA-seq Tutorial Data":
+      "Configured Datasets":
+        - "https://zenodo.org/record/1324070/files/wt_H3K4me3_read1.fastq.gz"
+        - "https://zenodo.org/record/1324070/files/wt_H3K4me3_read12.fastq.gz"
+      "RNA-seq Tutorial Data":
         - "https://benchmarking-inputs.s3.amazonaws.com/SRR24043307/SRR24043307-1.fastq.gz"
         - "https://benchmarking-inputs.s3.amazonaws.com/SRR24043307/SRR24043307-2.fastq.gz"
-      - "ChIP-Seq Input Data":
+      "ChIP-Seq Input Data":
         - "https://zenodo.org/record/1324070/files/wt_H3K4me3_read1.fastq.gz"
         - "https://zenodo.org/record/1324070/files/wt_H3K4me3_read2.fastq.gz"

--- a/mixins/postinstall.yml
+++ b/mixins/postinstall.yml
@@ -1,7 +1,7 @@
 postInstallJob:
   enabled: true
   image: quay.io/galaxyproject/abm:2.13.0
-  galaxyUser: "suderman@jhu.edu"
+  galaxyUser: "admin@galaxyproject.org"
   bootstrapConfig: |
     version: 1
     # Workflow imports

--- a/mixins/postinstall.yml
+++ b/mixins/postinstall.yml
@@ -18,10 +18,13 @@ postInstallJob:
     datasets:
       "Configured Datasets":
         - "https://zenodo.org/record/1324070/files/wt_H3K4me3_read1.fastq.gz"
-        - "https://zenodo.org/record/1324070/files/wt_H3K4me3_read12.fastq.gz"
+        - "https://zenodo.org/record/1324070/files/wt_H3K4me3_read2.fastq.gz"
       "RNA-seq Tutorial Data":
         - "https://benchmarking-inputs.s3.amazonaws.com/SRR24043307/SRR24043307-1.fastq.gz"
         - "https://benchmarking-inputs.s3.amazonaws.com/SRR24043307/SRR24043307-2.fastq.gz"
       "ChIP-Seq Input Data":
-        - "https://zenodo.org/record/1324070/files/wt_H3K4me3_read1.fastq.gz"
-        - "https://zenodo.org/record/1324070/files/wt_H3K4me3_read2.fastq.gz"
+        - url: "https://zenodo.org/record/1324070/files/wt_H3K4me3_read1.fastq.gz"
+          name: read1
+        - url: "https://zenodo.org/record/1324070/files/wt_H3K4me3_read2.fastq.gz"
+          name: read2
+  

--- a/roles/galaxy_k8s_deployment/files/profiles/anvil.yaml
+++ b/roles/galaxy_k8s_deployment/files/profiles/anvil.yaml
@@ -2,6 +2,7 @@ postInstallJob:
   enabled: true
   galaxyUser: "default-user@galaxyproject.org"
   bootstrapConfig: |
+    version: 1
     datasets:
       "Imported Datasets":
         - "https://zenodo.org/records/13987631/files/Saccharomyces_cerevisiae.R64-1-1.113.gtf"

--- a/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
+++ b/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
@@ -237,6 +237,24 @@
         galaxy-project-logo-white-square.png: "{{ lookup('file', 'files/galaxy-project-logo-white-square.png') | b64encode }}"
         anvil-project-logo-white.png: "{{ lookup('file', 'files/anvil-project-logo-white.png') | b64encode }}"
 
+# - name: Write Galaxy post-install user values
+#   ansible.builtin.copy:
+#     dest: /tmp/galaxy-postinstall-user.yaml
+#     content: |
+#       postInstallJob:
+#         galaxyUser: "{{ galaxy_user }}"
+#     mode: '0644'
+#   delegate_to: localhost
+#   become: false
+#   when: galaxy_user | default('') | length > 0
+#
+# To also wire the file written above into the Helm values, uncomment the
+# `user_file` set line below and insert `user_file` between `profile` and `base`
+# in the returned list. It overrides the profile's galaxyUser, while user-defined
+# mixins (base) come last and still take precedence:
+#   {%- set user_file = ['/tmp/galaxy-postinstall-user.yaml'] if (galaxy_user | default('') | length > 0) else [] -%}
+#   {{ profile + user_file + base }}
+
 - name: Prepare Galaxy values files list
   set_fact:
     _galaxy_values_files: >-

--- a/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
+++ b/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
@@ -237,24 +237,12 @@
         galaxy-project-logo-white-square.png: "{{ lookup('file', 'files/galaxy-project-logo-white-square.png') | b64encode }}"
         anvil-project-logo-white.png: "{{ lookup('file', 'files/anvil-project-logo-white.png') | b64encode }}"
 
-- name: Write Galaxy post-install user values
-  ansible.builtin.copy:
-    dest: /tmp/galaxy-postinstall-user.yaml
-    content: |
-      postInstallJob:
-        galaxyUser: "{{ galaxy_user }}"
-    mode: '0644'
-  delegate_to: localhost
-  become: false
-  when: galaxy_user | default('') | length > 0
-
 - name: Prepare Galaxy values files list
   set_fact:
     _galaxy_values_files: >-
       {%- set base = galaxy_values_files if (galaxy_values_files is defined and galaxy_values_files | length > 0) else ['values/values.yml'] -%}
       {%- set profile = galaxy_import_profile | default([]) -%}
-      {%- set user_file = ['/tmp/galaxy-postinstall-user.yaml'] if (galaxy_user | default('') | length > 0) else [] -%}
-      {{ base + profile + user_file }}
+      {{ profile + base }}
 
 - name: Display Galaxy values files being used
   debug:


### PR DESCRIPTION
While debugging a problem I ran into with the post-install hook I noticed a couple of other issues:

1. Values in the default `anvil.yml` profile always clobber values in any other mixins that define a  `postInstallJob`.  This PR reorders the way the Helm values array so that user defined values always win over built in defaults.
2. There is also a `postInstallJob` that simply adds a `galaxyUser`. But the `galaxyUser` is also set in the `anvil.yml` profile.  Is there a reason for the separate step in the Ansible playbook?  I have commented it out for now.
3. If we eliminate the above extra task then the `galaxy_user` Ansible variable is not used and can be removed. 

