### PR TITLE
Update to Helm 4 and K8s 1.36

### DIFF
--- a/image_prep.yml
+++ b/image_prep.yml
@@ -31,8 +31,28 @@
       ansible.builtin.debug:
         msg: |
           Preparing image for host: {{ inventory_hostname }}
-          OS: {{ ansible_distribution }} {{ ansible_distribution_version }}
-          Architecture: {{ ansible_architecture }}
+          OS: {{ ansible_facts['distribution'] }} {{ ansible_facts['distribution_version'] }}
+          Architecture: {{ ansible_facts['architecture'] }}
+
+    - name: Wait for background apt/dpkg locks to be released and stop unattended-upgrades
+      ansible.builtin.shell: |
+        # Temporarily stop unattended-upgrades so it does not trigger again
+        systemctl stop unattended-upgrades || true
+        systemctl disable unattended-upgrades || true
+        
+        # Wait for any active lock to release
+        for i in $(seq 1 120); do
+          if ! fuser /var/lib/dpkg/lock-frontend /var/lib/apt/lists/lock >/dev/null 2>&1; then
+            echo "Apt locks are clear!"
+            exit 0
+          fi
+          echo "Apt/dpkg lock is currently held by another process. Waiting..."
+          sleep 5
+        done
+        echo "Timed out waiting for apt lock!"
+        exit 1
+      changed_when: false
+      failed_when: false # Ignore if fuser is missing, apt will try to run anyway
 
     - name: Update system packages
       ansible.builtin.apt:
@@ -69,6 +89,20 @@
       changed_when: true
       when: install_rke2_prerequisites | bool
 
+    # galaxyproject.cvmfs 0.5.0 only downloads the CERN GPG key for Ubuntu
+    # (jammy/noble). On Debian the repo config still references the same path,
+    # so we pre-seed it here. This workaround can be removed once upstream
+    # fixes the conditional in init_debian.yml.
+    - name: Download CernVM GPG key for Debian
+      ansible.builtin.get_url:
+        url: https://cvmrepo.web.cern.ch/cvmrepo/apt/cernvm.gpg
+        dest: /usr/share/keyrings/cernvm.gpg
+        mode: '0644'
+      become: true
+      when:
+        - install_cvmfs | bool
+        - ansible_facts['distribution'] == 'Debian'
+
   roles:
     - role: galaxyproject.cvmfs
       when: install_cvmfs | bool
@@ -76,6 +110,44 @@
     - role: image_preparation
 
   post_tasks:
+    # galaxyproject.cvmfs 0.5.0 uses `cvmfs_config_repo | bool` to guard this
+    # setup, which ansible-core now treats as false for dict values.
+    - name: Ensure Galaxy CVMFS config repository is configured
+      when:
+        - install_cvmfs | bool
+        - galaxy_cvmfs_repos_enabled == 'config-repo'
+      block:
+        - name: Create Galaxy CVMFS config repo config
+          ansible.builtin.copy:
+            content: |
+              ## This file is maintained by Ansible - CHANGES WILL BE OVERWRITTEN
+              CVMFS_SERVER_URL="{{ galaxy_cvmfs_config_repo.urls | join(';') }}"
+              CVMFS_PUBLIC_KEY="{{ galaxy_cvmfs_config_repo.key.path }}"
+            dest: /etc/cvmfs/config.d/{{ galaxy_cvmfs_config_repo.repository.repository }}.conf
+            owner: root
+            group: root
+            mode: "0444"
+          register: galaxy_cvmfs_config_repo_conf
+
+        - name: Set Galaxy CVMFS config repo defaults
+          ansible.builtin.copy:
+            content: |
+              ## This file is maintained by Ansible - CHANGES WILL BE OVERWRITTEN
+              CVMFS_CONFIG_REPOSITORY="{{ galaxy_cvmfs_config_repo.repository.repository }}"
+              CVMFS_DEFAULT_DOMAIN="{{ galaxy_cvmfs_config_repo.domain }}"
+              CVMFS_USE_GEOAPI="{{ galaxy_cvmfs_config_repo.use_geoapi | default(false) | ternary('yes', 'no') }}"
+            dest: /etc/cvmfs/default.d/80-ansible-galaxyproject-cvmfs.conf
+            owner: root
+            group: root
+            mode: "0444"
+          register: galaxy_cvmfs_config_repo_defaults
+
+        - name: Restart autofs after Galaxy CVMFS config repo changes
+          ansible.builtin.service:
+            name: autofs
+            state: restarted
+          when: galaxy_cvmfs_config_repo_conf.changed or galaxy_cvmfs_config_repo_defaults.changed
+
     - name: Verify CVMFS client installed
       ansible.builtin.command: which cvmfs_config
       register: cvmfs_config_check

--- a/requirements.yml
+++ b/requirements.yml
@@ -7,8 +7,8 @@ collections:
   - name: ansible.posix
     version: ">=2.1.0,<3.0.0"
   - name: kubernetes.core
-    version: ">=6.1.0,<7.0.0"
+    version: ">=6.4.0,<7.0.0"
 
 roles:
   - name: galaxyproject.cvmfs
-    version: "0.3.2"
+    version: "0.5.0"

--- a/roles/galaxy_k8s_deployment/defaults/main.yml
+++ b/roles/galaxy_k8s_deployment/defaults/main.yml
@@ -20,8 +20,8 @@ cvmfs_quota_limit: 4000
 cvmfs_http_proxies: ["DIRECT"]
 
 # System Setup (used only if setup_system is true)
-rke2_version: v1.35.1+rke2r1  # https://github.com/rancher/rke2/tags
-helm_version: v3.19.0         # https://github.com/helm/helm/tags
+rke2_version: v1.36.2+rke2r1  # https://github.com/rancher/rke2/tags
+helm_version: v4.2.2          # https://github.com/helm/helm/tags
 system_packages:
   - python3
   - python3-pip
@@ -109,7 +109,7 @@ galaxy_values_files:
 # Size requested by Galaxy's `galaxy-pvc` claim.
 # Keep it less than or equal to the usable space behind `nfs_size`, and
 # leave headroom if other PVCs also use the `nfs` storage class.
-galaxy_persistence_size: "128Gi"
+galaxy_persistence_size: "115Gi"
 galaxy_db_password: "galaxydbpassword"
 galaxy_user: "default-user@galaxyproject.org"
 galaxy_bootstrap_api_key: "galaxypassword"

--- a/roles/galaxy_k8s_deployment/defaults/main.yml
+++ b/roles/galaxy_k8s_deployment/defaults/main.yml
@@ -93,6 +93,7 @@ restore_galaxy: false
 ingress_version: "4.13.2"  # https://github.com/kubernetes/ingress-nginx?tab=readme-ov-file#supported-versions-table
 
 # Galaxy Application Configuration
+use_local_chart: false
 galaxy_prefix: "/"
 galaxy_chart: cloudve/galaxy
 galaxy_chart_version: "6.8.0"

--- a/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
+++ b/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
@@ -284,6 +284,7 @@
     chart_version: "{{ omit if (use_local_chart | default(false) | bool) else galaxy_chart_version }}"
     kubeconfig: "{{ kubeconfig_path }}"
     update_repo_cache: "{{ not (use_local_chart | default(false) | bool) }}"
+    timeout: "20m0s"
     values_files: "{{ lookup('sequence', 'start=0 end=' ~ (_galaxy_values_files|length - 1) ~ ' format=/tmp/galaxy_values_%d.yml', wantlist=True) }}"
     values: "{{ _helm_values_base | combine(_helm_values_gcp_batch if (enable_gcp_batch | default(false) | bool) else {}, recursive=True) | combine(_helm_values_cnpg_plugin if (restore_galaxy and detected_galaxy_pvc_uuid | default('') != '') else {}, recursive=True) }}"
     set_values: "{{ galaxy_helm_extra_sets | default([]) + _helm_prefix_sets }}"

--- a/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
+++ b/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
@@ -180,7 +180,7 @@
 
 - name: Get node internal IP for NFS access
   set_fact:
-    nfs_server: "{{ ansible_default_ipv4.address }}"
+    nfs_server: "{{ ansible_facts['default_ipv4']['address'] }}"
   when: enable_gcp_batch | default(false) | bool
 
 - name: Verify NFS service exists

--- a/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
+++ b/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
@@ -269,14 +269,21 @@
   loop_control:
     index_var: idx
 
+- name: Copy packaged local Galaxy chart to the remote host
+  ansible.builtin.copy:
+    src: "galaxy-{{ galaxy_chart_version }}.tgz"
+    dest: "/tmp/galaxy-chart.tgz"
+    mode: '0644'
+  when: use_local_chart | default(false) | bool
+
 - name: Helm install Galaxy
   kubernetes.core.helm:
     name: galaxy
     namespace: galaxy
-    chart_ref: "{{ galaxy_chart }}"
-    chart_version: "{{ galaxy_chart_version }}"
+    chart_ref: "{{ '/tmp/galaxy-chart.tgz' if (use_local_chart | default(false) | bool) else galaxy_chart }}"
+    chart_version: "{{ omit if (use_local_chart | default(false) | bool) else galaxy_chart_version }}"
     kubeconfig: "{{ kubeconfig_path }}"
-    update_repo_cache: true
+    update_repo_cache: "{{ not (use_local_chart | default(false) | bool) }}"
     values_files: "{{ lookup('sequence', 'start=0 end=' ~ (_galaxy_values_files|length - 1) ~ ' format=/tmp/galaxy_values_%d.yml', wantlist=True) }}"
     values: "{{ _helm_values_base | combine(_helm_values_gcp_batch if (enable_gcp_batch | default(false) | bool) else {}, recursive=True) | combine(_helm_values_cnpg_plugin if (restore_galaxy and detected_galaxy_pvc_uuid | default('') != '') else {}, recursive=True) }}"
     set_values: "{{ galaxy_helm_extra_sets | default([]) + _helm_prefix_sets }}"
@@ -392,6 +399,8 @@
   environment:
     KUBECONFIG: "{{ kubeconfig_path }}"
   loop:
+    - galaxy-web
+    - galaxy-job-0
     - galaxy-workflow
   when:
     - enable_gcp_batch | default(false) | bool

--- a/roles/galaxy_k8s_deployment/tasks/main.yml
+++ b/roles/galaxy_k8s_deployment/tasks/main.yml
@@ -4,36 +4,36 @@
 
 - name: Include system setup tasks
   ansible.builtin.include_tasks: system_setup.yml
-  when: setup_system | default(true)
+  when: setup_system | default(true) | bool
 
 - name: Include RKE2 cluster setup tasks
   ansible.builtin.include_tasks: rke2_setup.yml
-  when: setup_rke2 | default(true)
+  when: setup_rke2 | default(true) | bool
 
 - name: Include Helm repository setup tasks
   ansible.builtin.include_tasks: helm_setup.yml
-  when: setup_helm | default(false)
+  when: setup_helm | default(false) | bool
 
 - name: Include NFS storage setup tasks
   ansible.builtin.include_tasks: nfs_setup.yml
-  when: setup_nfs | default(true)
+  when: setup_nfs | default(true) | bool
 
 - name: Include Kubernetes storage setup tasks
   ansible.builtin.include_tasks: storage_setup.yml
-  when: setup_storage | default(true)
+  when: setup_storage | default(true) | bool
 
 - name: Include Kubernetes ingress setup tasks
   ansible.builtin.include_tasks: ingress_setup.yml
-  when: setup_ingress | default(true)
+  when: setup_ingress | default(true) | bool
 
 - name: Include Galaxy application setup tasks
   ansible.builtin.include_tasks: galaxy_application.yml
-  when: deploy_galaxy | default(false)
+  when: deploy_galaxy | default(false) | bool
 
 - name: Include Pulsar application setup tasks
   ansible.builtin.include_tasks: pulsar_application.yml
-  when: deploy_pulsar | default(false)
+  when: deploy_pulsar | default(false) | bool
 
 - name: Include Galaxy K8s Monitor setup tasks
   ansible.builtin.include_tasks: monitor_application.yml
-  when: deploy_monitor | default(true)
+  when: deploy_monitor | default(true) | bool

--- a/roles/galaxy_k8s_deployment/tasks/rke2_setup.yml
+++ b/roles/galaxy_k8s_deployment/tasks/rke2_setup.yml
@@ -57,21 +57,21 @@
   ansible.builtin.set_fact:
     kubeconfig_path: "/etc/rancher/rke2/rke2.yaml"
 
-- name: Create .kube directory for ubuntu user
+- name: Create .kube directory for login user
   ansible.builtin.file:
-    path: /home/ubuntu/.kube
+    path: "/home/{{ ansible_user }}/.kube"
     state: directory
-    owner: ubuntu
-    group: ubuntu
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
     mode: '0755'
   become: true
 
-- name: Copy kubeconfig to ubuntu user home directory
+- name: Copy kubeconfig to login user home directory
   ansible.builtin.copy:
     src: /etc/rancher/rke2/rke2.yaml
-    dest: /home/ubuntu/.kube/config
-    owner: ubuntu
-    group: ubuntu
+    dest: "/home/{{ ansible_user }}/.kube/config"
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
     mode: '0600'
     remote_src: true
   become: true

--- a/roles/galaxy_k8s_deployment/tasks/system_setup.yml
+++ b/roles/galaxy_k8s_deployment/tasks/system_setup.yml
@@ -27,10 +27,11 @@
     - /usr/local/bin
   become: true
 
-- name: Check if RKE2 is already installed
-  ansible.builtin.stat:
-    path: /usr/local/bin/rke2
-  register: rke2_binary
+- name: Check RKE2 version
+  ansible.builtin.command: rke2 --version
+  register: rke2_installed_version
+  failed_when: false
+  changed_when: false
 
 - name: Download RKE2 installation script
   ansible.builtin.get_url:
@@ -38,15 +39,15 @@
     dest: /tmp/install-rke2.sh
     mode: '0755'
     timeout: 30
-  when: not rke2_binary.stat.exists
+  when: rke2_installed_version.rc != 0 or rke2_version not in rke2_installed_version.stdout
   become: true
 
-- name: Install RKE2 binaries
+- name: Install/Upgrade RKE2 binaries
   ansible.builtin.shell: |
     INSTALL_RKE2_VERSION="{{ rke2_version }}" \
     INSTALL_RKE2_TYPE=server \
     /tmp/install-rke2.sh
-  when: not rke2_binary.stat.exists
+  when: rke2_installed_version.rc != 0 or rke2_version not in rke2_installed_version.stdout
   become: true
 
 - name: Create kubectl symlink
@@ -63,17 +64,24 @@
     state: absent
   become: true
 
+- name: Check Helm version
+  ansible.builtin.command: helm version --template '{{ '{{' }} .Version {{ '}}' }}'
+  register: helm_installed_version
+  failed_when: false
+  changed_when: false
+
 - name: Download Helm installation script
   ansible.builtin.get_url:
-    url: https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+    url: "https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-{{ helm_version | regex_replace('^v?([0-9]+).*', '\\1') }}"
     dest: /tmp/get_helm.sh
     mode: "0755"
+  when: helm_installed_version.rc != 0 or helm_version not in helm_installed_version.stdout
   become: true
 
-- name: Install Helm
+- name: Install/Upgrade Helm
   ansible.builtin.shell:
     cmd: /tmp/get_helm.sh --version {{ helm_version }}
-    creates: /usr/local/bin/helm
+  when: helm_installed_version.rc != 0 or helm_version not in helm_installed_version.stdout
   become: true
   environment:
     DESIRED_VERSION: "{{ helm_version }}"

--- a/roles/image_preparation/defaults/main.yml
+++ b/roles/image_preparation/defaults/main.yml
@@ -1,10 +1,10 @@
 ---
 # Default variables for image preparation role
-rke2_version: v1.35.1+rke2r1  # https://github.com/rancher/rke2/tags
-helm_version: v3.20.0  # https://github.com/helm/helm/tags
+rke2_version: v1.36.2+rke2r1  # https://github.com/rancher/rke2/tags
+helm_version: v4.2.2          # https://github.com/helm/helm/tags
 
 # Default user (Ubuntu uses 'ubuntu', Debian uses 'debian' on GCP)
-default_user: "{{ 'ubuntu' if ansible_distribution | default('Debian') == 'Ubuntu' else 'debian' }}"
+default_user: "{{ 'ubuntu' if ansible_facts['distribution'] | default('Debian') == 'Ubuntu' else 'debian' }}"
 
 # System packages to install (works on both Ubuntu and Debian)
 base_packages:

--- a/roles/image_preparation/files/container_images.yml
+++ b/roles/image_preparation/files/container_images.yml
@@ -5,7 +5,7 @@ container_images:
   - docker.io/bitnamilegacy/rabbitmq:3.10.7-debian-11-r3
   - docker.io/rancher/hardened-calico:v3.30.3-build20250909
   - docker.io/rancher/hardened-kubernetes:v1.34.1-rke2r1-build20250910
-  - docker.io/rancher/rke2-runtime:v1.34.1-rke2r1
+  - docker.io/rancher/rke2-runtime:v1.36.2-rke2r1
   - ghcr.io/cloudnative-pg/postgresql:17.2
   - registry.k8s.io/sig-storage/nfs-provisioner:v4.0.8
   - docker.io/bitnamilegacy/rabbitmq-cluster-operator:1.14.0-scratch-r5

--- a/roles/image_preparation/requirements.yml
+++ b/roles/image_preparation/requirements.yml
@@ -9,4 +9,4 @@ collections:
 
 roles:
   - name: galaxyproject.cvmfs
-    version: "0.3.2"
+    version: "0.5.0"

--- a/roles/image_preparation/tasks/base_packages.yml
+++ b/roles/image_preparation/tasks/base_packages.yml
@@ -1,4 +1,17 @@
 ---
+- name: Wait for background apt/dpkg locks to be released
+  ansible.builtin.shell: |
+    for i in $(seq 1 60); do
+      if ! fuser /var/lib/dpkg/lock-frontend /var/lib/apt/lists/lock >/dev/null 2>&1; then
+        exit 0
+      fi
+      sleep 5
+    done
+    exit 1
+  changed_when: false
+  failed_when: false
+  become: true
+
 - name: Update package cache
   ansible.builtin.apt:
     update_cache: true
@@ -26,7 +39,7 @@
     name: python3-openshift
     state: present
   become: true
-  when: ansible_distribution == 'Ubuntu'
+  when: ansible_facts['distribution'] == 'Ubuntu'
 
 - name: Install Docker prerequisites
   ansible.builtin.apt:
@@ -42,24 +55,32 @@
 
 - name: Add Docker GPG key
   ansible.builtin.get_url:
-    url: https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg
-    dest: /etc/apt/trusted.gpg.d/docker.asc
+    url: https://download.docker.com/linux/{{ ansible_facts['distribution'] | lower }}/gpg
+    dest: /usr/share/keyrings/docker.asc
     mode: '0644'
   when: install_docker | default(false) | bool
   become: true
 
 - name: Add Docker repository
-  ansible.builtin.apt_repository:
-    repo: "deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
+  ansible.builtin.deb822_repository:
+    name: docker
+    types: deb
+    uris: "https://download.docker.com/linux/{{ ansible_facts['distribution'] | lower }}"
+    suites: "{{ ansible_facts['distribution_release'] }}"
+    components: stable
+    architectures: amd64
+    signed_by: /usr/share/keyrings/docker.asc
     state: present
-    filename: docker
   when: install_docker | default(false) | bool
   become: true
+  register: _docker_repo
 
 - name: Update apt cache after adding Docker repo
   ansible.builtin.apt:
     update_cache: true
-  when: install_docker | default(false) | bool
+  when:
+    - install_docker | default(false) | bool
+    - _docker_repo is changed
   become: true
 
 - name: Install Docker Engine

--- a/roles/image_preparation/tasks/cleanup.yml
+++ b/roles/image_preparation/tasks/cleanup.yml
@@ -6,11 +6,14 @@
   become: true
 
 - name: Remove temporary files
-  ansible.builtin.shell: |
-    rm -rf /tmp/*
-    rm -rf /var/tmp/*
-    rm -f /var/cache/apt/archives/*.deb
+  ansible.builtin.shell:
+    cmd: |
+      # Exclude .ansible* to avoid deleting Ansible's own temp files mid-task
+      find /tmp -mindepth 1 -maxdepth 1 -not -name '.ansible*' -not -name 'ansible_*' -exec rm -rf {} +
+      find /var/tmp -mindepth 1 -maxdepth 1 -not -name '.ansible*' -not -name 'ansible_*' -exec rm -rf {} +
+      rm -f /var/cache/apt/archives/*.deb
   ignore_errors: true
+  changed_when: false
   become: true
 
 - name: Reset history

--- a/roles/image_preparation/tasks/helm.yml
+++ b/roles/image_preparation/tasks/helm.yml
@@ -1,7 +1,7 @@
 ---
 - name: Download Helm installation script
   ansible.builtin.get_url:
-    url: https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+    url: "https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-{{ helm_version | regex_replace('^v?([0-9]+).*', '\\1') }}"
     dest: /tmp/get_helm.sh
     mode: "0755"
   become: true

--- a/roles/image_preparation/tasks/main.yml
+++ b/roles/image_preparation/tasks/main.yml
@@ -1,23 +1,23 @@
 ---
 - name: Include base packages installation
   ansible.builtin.include_tasks: base_packages.yml
-  when: install_base_packages | default(true)
+  when: install_base_packages | default(true) | bool
 
 - name: Include system configuration
   ansible.builtin.include_tasks: system_config.yml
-  when: install_base_packages | default(true)
+  when: install_base_packages | default(true) | bool
 
 - name: Include RKE2 prerequisites installation
   ansible.builtin.include_tasks: rke2_prerequisites.yml
-  when: install_rke2_prerequisites | default(true)
+  when: install_rke2_prerequisites | default(true) | bool
 
 - name: Include Helm installation
   ansible.builtin.include_tasks: helm.yml
-  when: install_helm | default(true)
+  when: install_helm | default(true) | bool
 
 - name: Include container prefetch tasks
   ansible.builtin.include_tasks: container_prefetch.yml
-  when: prefetch_container_images | default(true)
+  when: prefetch_container_images | default(true) | bool
 
 - name: Include cleanup tasks
   ansible.builtin.include_tasks: cleanup.yml

--- a/values/values.yml
+++ b/values/values.yml
@@ -1,7 +1,7 @@
 
 image:
   repository: quay.io/galaxyproject/galaxy-min
-  tag: "26.0"
+  tag: "26.1-auto"
 
 ingress:
   enabled: true
@@ -86,7 +86,7 @@ configs:
         docker_extra_volumes: "/cvmfs/data.galaxyproject.org:/cvmfs/data.galaxyproject.org:ro,/cvmfs/cloud.galaxyproject.org:/cvmfs/cloud.galaxyproject.org:ro"
 
         # Custom VM image with CVMFS pre-configured (update date as needed)
-        custom_vm_image: projects/anvil-and-terra-development/global/images/galaxy-k8s-boot-debian12-v2026-02-24
+        custom_vm_image: projects/anvil-and-terra-development/global/images/galaxy-k8s-boot-v2026-06-30
         # Job execution settings
         max_retry_count: 3
         # Max time a job will run before being deleted. Must be in seconds (end with 's'). Default 24hrs.
@@ -224,3 +224,23 @@ extraFileMappings:
               </div>
           </body>
       </html>
+
+webHandlers:
+  gunicorn:
+    timeout: 900             # 15 minutes!
+  startupProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    failureThreshold: 120    # 120 * 10 = 20 minutes!
+
+workflowHandlers:
+  startupProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    failureThreshold: 120
+
+jobHandlers:
+  startupProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    failureThreshold: 120


### PR DESCRIPTION
Friends with https://github.com/galaxyproject/galaxy-helm/pull/545, which implies the Galaxy chart version will need to be bumped here once that PR is merged.

Also, aurrently points to Galaxy Docker `26.1-auto` image because 26.1 is not yet released but I want to test this on 26.1 by default.