### PR TITLE
Derive GCP Batch region from the VM zone automatically

### DIFF
--- a/roles/galaxy_k8s_deployment/README.md
+++ b/roles/galaxy_k8s_deployment/README.md
@@ -199,8 +199,16 @@ pulsar_api_key: ""                         # Pulsar API key
 ```yaml
 enable_gcp_batch: true                     # Auto-configure Galaxy for GCP Batch runner
 gcp_batch_service_account_email: ""        # Service account email for Batch
-gcp_batch_region: "us-east4"               # Region for GCP Batch
+gcp_batch_region: ""                       # Region for GCP Batch; empty = derive
+                                           # it from the VM's zone
 ```
+
+When `gcp_batch_region` is empty, the region is derived from the VM's own zone
+via the GCE metadata server (`us-central1-f` becomes `us-central1`) so Batch
+jobs run in the same region as the cluster's NFS server. Set it explicitly to
+pin a region; an explicit value is never overridden by detection. If detection
+fails and no value is set, the region in the Helm values files is used unchanged
+and a warning is printed.
 
 ## Dependencies
 

--- a/roles/galaxy_k8s_deployment/defaults/main.yml
+++ b/roles/galaxy_k8s_deployment/defaults/main.yml
@@ -126,11 +126,15 @@ galaxy_job_max_mem: 4
 # This will:
 #   - Detect and configure NFS LoadBalancer IP
 #   - Auto-detect NFS export path for Galaxy PVC
+#   - Derive the Batch region from the VM's zone (unless gcp_batch_region is set)
 #   - Update job_conf.yml with GCP Batch runner configuration
 #   - Restart Galaxy deployments to apply changes
 enable_gcp_batch: true
 gcp_batch_service_account_email: ""
-gcp_batch_region: "us-east4"
+# Leave empty to derive the region from the VM's own zone via the metadata server.
+# An explicit value is never overridden by detection. When this is empty and
+# detection fails, the region in the Helm values files is used unchanged.
+gcp_batch_region: ""
 
 # Pulsar Application Configuration
 pulsar_chart: cloudve/pulsar

--- a/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
+++ b/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
@@ -283,32 +283,56 @@
   when: use_local_chart | default(false) | bool
 
 # Derive the GCP Batch region from the VM's own zone so Batch jobs run in-region
-# with the cluster's NFS server instead of the us-east4 default in values.yml. The
-# metadata server reports the true zone (e.g. projects/NUM/zones/us-central1-f)
-# regardless of how the VM was launched; strip the trailing "-<letter>" to get the
-# region. Falls back to the gcp_batch_region default (defaults/main.yml) on failure.
+# with the cluster's NFS server. The metadata server reports the true zone
+# (e.g. projects/NUM/zones/us-central1-f) regardless of how the VM was launched;
+# strip the trailing "-<letter>" to get the region. An explicitly set
+# gcp_batch_region always wins, and when neither is available the region in the
+# Helm values files is left untouched (see the _helm_values_gcp_batch merge below).
 - name: Detect GCP zone from the metadata server
   ansible.builtin.uri:
     url: http://metadata.google.internal/computeMetadata/v1/instance/zone
     headers:
       Metadata-Flavor: Google
     return_content: true
+    timeout: 5
   register: gcp_zone_meta
   failed_when: false
-  when: enable_gcp_batch | default(false) | bool
+  when:
+    - enable_gcp_batch | default(false) | bool
+    - gcp_batch_region | default('') | length == 0
 
 - name: Derive gcp_batch_region from the detected zone
   set_fact:
-    gcp_batch_region: "{{ gcp_zone_meta.content | regex_replace('.*/', '') | regex_replace('-[a-z]$', '') }}"
+    gcp_batch_region: "{{ _detected_region }}"
+    _gcp_batch_region_source: "zone {{ _detected_zone }} reported by the metadata server"
+  vars:
+    _detected_zone: "{{ gcp_zone_meta.content | default('') | trim | regex_replace('.*/', '') }}"
+    _detected_region: "{{ _detected_zone | regex_replace('-[a-z]$', '') }}"
   when:
     - enable_gcp_batch | default(false) | bool
+    - gcp_batch_region | default('') | length == 0
     - gcp_zone_meta.status | default(0) == 200
-    - gcp_zone_meta.content | default('') | length > 0
+    - _detected_region is match('^[a-z]+-[a-z]+[0-9]+$')
 
 - name: Display GCP Batch region in use
   debug:
-    msg: "GCP Batch region: {{ gcp_batch_region }} (from zone {{ gcp_zone_meta.content | default('n/a') | regex_replace('.*/', '') }})"
-  when: enable_gcp_batch | default(false) | bool
+    msg: "GCP Batch region: {{ gcp_batch_region }} (from {{ _gcp_batch_region_source | default('the gcp_batch_region variable', true) }})"
+  when:
+    - enable_gcp_batch | default(false) | bool
+    - gcp_batch_region | default('') | length > 0
+
+- name: Warn that the GCP Batch region could not be determined
+  debug:
+    msg: >-
+      WARNING: could not derive the GCP Batch region from the metadata server
+      (HTTP status {{ gcp_zone_meta.status | default('n/a') }}, content
+      '{{ gcp_zone_meta.content | default('') | trim }}'). Batch jobs will use the
+      region set in the Helm values files, which breaks job I/O against the
+      cluster's NFS server if that region is not this VM's region. Set
+      gcp_batch_region explicitly to silence this warning.
+  when:
+    - enable_gcp_batch | default(false) | bool
+    - gcp_batch_region | default('') | length == 0
 
 - name: Helm install Galaxy
   kubernetes.core.helm:
@@ -320,7 +344,7 @@
     update_repo_cache: "{{ not (use_local_chart | default(false) | bool) }}"
     timeout: "20m0s"
     values_files: "{{ lookup('sequence', 'start=0 end=' ~ (_galaxy_values_files|length - 1) ~ ' format=/tmp/galaxy_values_%d.yml', wantlist=True) }}"
-    values: "{{ _helm_values_base | combine(_helm_values_gcp_batch if (enable_gcp_batch | default(false) | bool) else {}, recursive=True) | combine(_helm_values_cnpg_plugin if (restore_galaxy and detected_galaxy_pvc_uuid | default('') != '') else {}, recursive=True) }}"
+    values: "{{ _helm_values_base | combine(_helm_values_gcp_batch if (enable_gcp_batch | default(false) | bool and gcp_batch_region | default('') | length > 0) else {}, recursive=True) | combine(_helm_values_cnpg_plugin if (restore_galaxy and detected_galaxy_pvc_uuid | default('') != '') else {}, recursive=True) }}"
     set_values: "{{ galaxy_helm_extra_sets | default([]) + _helm_prefix_sets }}"
   vars:
     _helm_prefix_sets:
@@ -342,9 +366,10 @@
               k8s:
                 max_cores: "{{ galaxy_job_max_cores }}"
                 max_mem: "{{ galaxy_job_max_mem }}"
-    # Override only the gcp_batch runner region (derived from the VM zone above);
-    # deep-merges over the runner block in values/values.yml, preserving every
-    # other setting. Merged into the Helm values only when enable_gcp_batch is set.
+    # Overrides only the gcp_batch runner region; deep-merges over the runner block
+    # in the values files, preserving every other setting. Merged in only when
+    # enable_gcp_batch is set and a region is known, so a region in a user-supplied
+    # values file survives when detection fails.
     _helm_values_gcp_batch:
       configs:
         job_conf.yml:

--- a/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
+++ b/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
@@ -282,6 +282,34 @@
     mode: '0644'
   when: use_local_chart | default(false) | bool
 
+# Derive the GCP Batch region from the VM's own zone so Batch jobs run in-region
+# with the cluster's NFS server instead of the us-east4 default in values.yml. The
+# metadata server reports the true zone (e.g. projects/NUM/zones/us-central1-f)
+# regardless of how the VM was launched; strip the trailing "-<letter>" to get the
+# region. Falls back to the gcp_batch_region default (defaults/main.yml) on failure.
+- name: Detect GCP zone from the metadata server
+  ansible.builtin.uri:
+    url: http://metadata.google.internal/computeMetadata/v1/instance/zone
+    headers:
+      Metadata-Flavor: Google
+    return_content: true
+  register: gcp_zone_meta
+  failed_when: false
+  when: enable_gcp_batch | default(false) | bool
+
+- name: Derive gcp_batch_region from the detected zone
+  set_fact:
+    gcp_batch_region: "{{ gcp_zone_meta.content | regex_replace('.*/', '') | regex_replace('-[a-z]$', '') }}"
+  when:
+    - enable_gcp_batch | default(false) | bool
+    - gcp_zone_meta.status | default(0) == 200
+    - gcp_zone_meta.content | default('') | length > 0
+
+- name: Display GCP Batch region in use
+  debug:
+    msg: "GCP Batch region: {{ gcp_batch_region }} (from zone {{ gcp_zone_meta.content | default('n/a') | regex_replace('.*/', '') }})"
+  when: enable_gcp_batch | default(false) | bool
+
 - name: Helm install Galaxy
   kubernetes.core.helm:
     name: galaxy
@@ -314,7 +342,15 @@
               k8s:
                 max_cores: "{{ galaxy_job_max_cores }}"
                 max_mem: "{{ galaxy_job_max_mem }}"
-    _helm_values_gcp_batch: {}
+    # Override only the gcp_batch runner region (derived from the VM zone above);
+    # deep-merges over the runner block in values/values.yml, preserving every
+    # other setting. Merged into the Helm values only when enable_gcp_batch is set.
+    _helm_values_gcp_batch:
+      configs:
+        job_conf.yml:
+          runners:
+            gcp_batch:
+              region: "{{ gcp_batch_region }}"
     _helm_values_cnpg_plugin:
       postgresql:
         cluster:

--- a/values/values.yml
+++ b/values/values.yml
@@ -64,6 +64,8 @@ configs:
         workers: 4
         # Basic GCP settings
         project_id: anvil-and-terra-development
+        # Overridden by the region derived from the VM's zone, or by an explicit
+        # gcp_batch_region, when enable_gcp_batch is set
         region: us-east4
         service_account_email: galaxy-batch-runner@anvil-and-terra-development.iam.gserviceaccount.com
 


### PR DESCRIPTION
The region that Batch jobs were dispatched to was hard coded to `us-east4`, which caused problems when the VM was launched in a different region, e.g. to use a GPU in `us-central1`. 

Now Helm queries the metadata server for the VM's zone and strips the trailing "-&lt;letter>" to get the region. The region is then injected it into the `gcp_batch` runner via a Helm values override. 
