### PR TITLE
Add support for linking a Terra workspace and restart only the job handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,11 @@ image_prep.ini
 vm.ini
 ea-no-commit/
 conductor/
+.clinerules
+.windsurfrules
+AGENTS.md
+CLAUDE.md
+gcp.pem
+opencode.json
+sqz.mdc
+sqz-compress.json

--- a/bin/user_data.sh
+++ b/bin/user_data.sh
@@ -86,6 +86,15 @@ write_files:
       GCP_BATCH_SERVICE_ACCOUNT_EMAIL=$(curl -s -f "http://metadata.google.internal/computeMetadata/v1/instance/attributes/gcp_batch_service_account_email" -H "Metadata-Flavor: Google" 2>/dev/null || echo "galaxy-batch-runner@anvil-and-terra-development.iam.gserviceaccount.com")
       echo "[$(date)] - GCP Batch service account email: ${GCP_BATCH_SERVICE_ACCOUNT_EMAIL}"
 
+      # Terra / AnVIL launch context — baked in at VM launch time by the
+      # orchestrating service (e.g. Leonardo). These are intentionally literal
+      # values, not metadata reads, so the orchestrator substitutes them before
+      # the script is sent to the instance.
+      TERRA_WORKSPACE=""
+      TERRA_NAMESPACE=""
+      TERRA_DRS_URL=""
+      TERRA_API_URL=""
+
       GIT_REPO=$(curl -s -f "http://metadata.google.internal/computeMetadata/v1/instance/attributes/git-repo" -H "Metadata-Flavor: Google" 2>/dev/null || echo "https://github.com/galaxyproject/galaxy-k8s-boot.git")
       GIT_BRANCH=$(curl -s -f "http://metadata.google.internal/computeMetadata/v1/instance/attributes/git-branch" -H "Metadata-Flavor: Google" 2>/dev/null || echo "master")
 
@@ -97,6 +106,10 @@ write_files:
         --accept-host-key
         --limit 127.0.0.1
         --extra-vars "gcp_batch_service_account_email=${GCP_BATCH_SERVICE_ACCOUNT_EMAIL}"
+        --extra-vars "terra_workspace=${TERRA_WORKSPACE}"
+        --extra-vars "terra_namespace=${TERRA_NAMESPACE}"
+        --extra-vars "terra_drs_url=${TERRA_DRS_URL}"
+        --extra-vars "terra_api_url=${TERRA_API_URL}"
       )
 
       if [ "$RESTORE_GALAXY" = "true" ]; then

--- a/roles/galaxy_k8s_deployment/defaults/main.yml
+++ b/roles/galaxy_k8s_deployment/defaults/main.yml
@@ -94,9 +94,9 @@ ingress_version: "4.13.2"  # https://github.com/kubernetes/ingress-nginx?tab=rea
 
 # Galaxy Application Configuration
 use_local_chart: false
-galaxy_prefix: "/"
+galaxy_prefix: "/galaxy"
 galaxy_chart: cloudve/galaxy
-galaxy_chart_version: "6.8.1"
+galaxy_chart_version: "6.8.2"
 galaxy_deps_chart: cloudve/galaxy-deps
 galaxy_deps_version: "1.1.1"
 
@@ -135,6 +135,13 @@ gcp_batch_service_account_email: ""
 # An explicit value is never overridden by detection. When this is empty and
 # detection fails, the region in the Helm values files is used unchanged.
 gcp_batch_region: ""
+
+# Terra / AnVIL launch context
+# Supplied at VM launch time by the orchestrating service (e.g. Leonardo).
+terra_workspace: ""
+terra_namespace: ""
+terra_drs_url: ""
+terra_api_url: ""
 
 # Pulsar Application Configuration
 pulsar_chart: cloudve/pulsar

--- a/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
+++ b/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
@@ -465,17 +465,17 @@
 # job_conf.yml is mounted with subPath, and Kubernetes never propagates ConfigMap
 # updates into subPath mounts; every deployment that mounts it keeps the config it
 # started with until it is restarted.
-# The deployments to restart are listed explicitly in galaxy_job_conf_deployments
-# below; update that list if the chart adds or renames handlers. The guard task
-# fails the play when a job handler exists in the cluster but is missing from the
-# list, so an omission cannot silently leave a handler running on stale config.
-- name: Restart Galaxy deployments and wait for them to pick up configuration changes
+# Only job handlers need the new config: gcp_batch_volumes is a runner-plugin
+# setting, and Galaxy instantiates runner plugins solely in processes where
+# app.is_job_handler is true (galaxy.jobs.manager.JobManager.start). The web and
+# workflow-scheduler pods attach to no handler pool, so their copy of job_conf.yml
+# is never read by a runner and restarting them only lengthens the deployment.
+- name: Restart Galaxy job handlers and wait for them to pick up configuration changes
   vars:
-    galaxy_job_conf_deployments:
-      - galaxy-web
-      - galaxy-workflow
-      - galaxy-job-0
     galaxy_job_handler_pattern: '^galaxy-job-[0-9]+$'
+    galaxy_job_handler_deployments: >-
+      {{ galaxy_deployments.resources | default([]) | map(attribute='metadata.name')
+         | select('match', galaxy_job_handler_pattern) | list }}
   when:
     - enable_gcp_batch | default(false) | bool
     - nfs_export_path is defined
@@ -488,33 +488,33 @@
         kubeconfig: "{{ kubeconfig_path }}"
       register: galaxy_deployments
 
-    - name: Fail if a job handler is missing from the restart list
-      vars:
-        cluster_job_handlers: >-
-          {{ galaxy_deployments.resources | map(attribute='metadata.name')
-             | select('match', galaxy_job_handler_pattern) | list }}
+    # Matching nothing would silently skip the restart and leave every handler on a
+    # job_conf.yml without gcp_batch_volumes, failing every Batch job. Fail instead,
+    # so a chart that renames its handler deployments is caught here.
+    - name: Fail if no job handler deployments were found
       fail:
         msg: >-
-          Job handler(s)
-          {{ cluster_job_handlers | difference(galaxy_job_conf_deployments) | join(', ') }}
-          exist in the galaxy namespace but are missing from
-          galaxy_job_conf_deployments. They would keep a stale job_conf.yml and every
-          GCP Batch job they dispatch would fail. Add them to the list in this file.
-      when: cluster_job_handlers | difference(galaxy_job_conf_deployments) | length > 0
+          No deployment in the galaxy namespace matches
+          {{ galaxy_job_handler_pattern }}. Found:
+          {{ galaxy_deployments.resources | map(attribute='metadata.name') | join(', ') }}.
+          Update galaxy_job_handler_pattern to match the chart's job handler
+          deployments, otherwise they keep a stale job_conf.yml and every GCP Batch
+          job they dispatch would fail.
+      when: galaxy_job_handler_deployments | length == 0
 
-    - name: Restart Galaxy deployments to pick up configuration changes
+    - name: Restart Galaxy job handlers to pick up configuration changes
       shell: kubectl rollout restart deployment {{ item }} -n galaxy
       environment:
         KUBECONFIG: "{{ kubeconfig_path }}"
-      loop: "{{ galaxy_job_conf_deployments }}"
+      loop: "{{ galaxy_job_handler_deployments }}"
 
-    - name: Wait for restarted deployments to finish rolling out
+    - name: Wait for restarted job handlers to finish rolling out
       # 30 minutes per deployment; first-boot rollouts are slow while Galaxy builds
       # the tool panel and the CVMFS caches warm up.
       shell: kubectl rollout status deployment {{ item }} -n galaxy --timeout=1800s
       environment:
         KUBECONFIG: "{{ kubeconfig_path }}"
-      loop: "{{ galaxy_job_conf_deployments }}"
+      loop: "{{ galaxy_job_handler_deployments }}"
       changed_when: false
 
     # Fail loudly rather than leaving a cluster that looks healthy but errors every
@@ -528,5 +528,5 @@
         /galaxy/server/config/job_conf.yml
       environment:
         KUBECONFIG: "{{ kubeconfig_path }}"
-      loop: "{{ galaxy_job_conf_deployments | select('match', galaxy_job_handler_pattern) | list }}"
+      loop: "{{ galaxy_job_handler_deployments }}"
       changed_when: false

--- a/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
+++ b/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
@@ -355,6 +355,12 @@
         size: "{{ galaxy_persistence_size }}"
       postgresql:
         galaxyDatabasePassword: "{{ galaxy_db_password }}"
+      terra:
+        launch:
+          workspace: "{{ terra_workspace | default('') }}"
+          namespace: "{{ terra_namespace | default('') }}"
+          drsURL: "{{ terra_drs_url | default('') }}"
+          apiURL: "{{ terra_api_url | default('') }}"
       configs:
         galaxy.yml:
           galaxy:


### PR DESCRIPTION
Re. the change to restart only the job handler:

`gcp_batch_volumes` is a runner-plugin setting, and Galaxy instantiates runner plugins only in processes where `app.is_job_handler` is `true` (JobManager.start -> JobHandler -> get_job_runner_plugins). Under the galaxy chart, handling.assign is set explicitly to db-skip-locked, so handler membership comes solely from `--attach-to-pool job-handlers`, which only the galaxy-job-N deployments pass. The web and workflow-scheduler pods therefore never read the patched value; their restart added 6-7 minutes to every deployment for no effect so I think it's reasonable to skip.

I left the 26.1-auto image as the target and updated the Galaxy Helm chart version so these 2 PRs are 'part' of this PR: https://github.com/galaxyproject/galaxy/pull/23224 and https://github.com/galaxyproject/galaxy-helm/pull/549 