### PR TITLE
Merge dev into anvil: Terra workspace linking and forwarded header support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,11 @@ image_prep.ini
 vm.ini
 ea-no-commit/
 conductor/
+.clinerules
+.windsurfrules
+AGENTS.md
+CLAUDE.md
+gcp.pem
+opencode.json
+sqz.mdc
+sqz-compress.json

--- a/bin/user_data.sh
+++ b/bin/user_data.sh
@@ -86,6 +86,14 @@ write_files:
       GCP_BATCH_SERVICE_ACCOUNT_EMAIL=$(curl -s -f "http://metadata.google.internal/computeMetadata/v1/instance/attributes/gcp_batch_service_account_email" -H "Metadata-Flavor: Google" 2>/dev/null || echo "galaxy-batch-runner@anvil-and-terra-development.iam.gserviceaccount.com")
       echo "[$(date)] - GCP Batch service account email: ${GCP_BATCH_SERVICE_ACCOUNT_EMAIL}"
 
+      # Set this to "true" only when an external L7 proxy terminates TLS and is the
+      # only way in (e.g. Leonardo on Terra). It makes ingress-nginx trust the
+      # caller-supplied X-Forwarded-* headers, which is what lets tusd generate
+      # https:// upload URLs instead of http:// ones the browser blocks as mixed
+      # content. On a directly reachable VM it would let anyone forge those headers.
+      INGRESS_USE_FORWARDED_HEADERS=$(curl -s -f "http://metadata.google.internal/computeMetadata/v1/instance/attributes/ingress_use_forwarded_headers" -H "Metadata-Flavor: Google" 2>/dev/null || echo "false")
+      echo "[$(date)] - Trust caller-supplied X-Forwarded-* headers: ${INGRESS_USE_FORWARDED_HEADERS}"
+
       # Terra / AnVIL launch context — baked in at VM launch time by the
       # orchestrating service (e.g. Leonardo). These are intentionally literal
       # values, not metadata reads, so the orchestrator substitutes them before
@@ -110,6 +118,7 @@ write_files:
         --extra-vars "terra_namespace=${TERRA_NAMESPACE}"
         --extra-vars "terra_drs_url=${TERRA_DRS_URL}"
         --extra-vars "terra_api_url=${TERRA_API_URL}"
+        --extra-vars "ingress_use_forwarded_headers=${INGRESS_USE_FORWARDED_HEADERS}"
       )
 
       if [ "$RESTORE_GALAXY" = "true" ]; then

--- a/bin/user_data.sh
+++ b/bin/user_data.sh
@@ -86,6 +86,15 @@ write_files:
       GCP_BATCH_SERVICE_ACCOUNT_EMAIL=$(curl -s -f "http://metadata.google.internal/computeMetadata/v1/instance/attributes/gcp_batch_service_account_email" -H "Metadata-Flavor: Google" 2>/dev/null || echo "galaxy-batch-runner@anvil-and-terra-development.iam.gserviceaccount.com")
       echo "[$(date)] - GCP Batch service account email: ${GCP_BATCH_SERVICE_ACCOUNT_EMAIL}"
 
+      # Terra / AnVIL launch context — baked in at VM launch time by the
+      # orchestrating service (e.g. Leonardo). These are intentionally literal
+      # values, not metadata reads, so the orchestrator substitutes them before
+      # the script is sent to the instance.
+      TERRA_WORKSPACE=""
+      TERRA_NAMESPACE=""
+      TERRA_DRS_URL=""
+      TERRA_API_URL=""
+
       GIT_REPO=$(curl -s -f "http://metadata.google.internal/computeMetadata/v1/instance/attributes/git-repo" -H "Metadata-Flavor: Google" 2>/dev/null || echo "https://github.com/galaxyproject/galaxy-k8s-boot.git")
       GIT_BRANCH=$(curl -s -f "http://metadata.google.internal/computeMetadata/v1/instance/attributes/git-branch" -H "Metadata-Flavor: Google" 2>/dev/null || echo "master")
 
@@ -97,6 +106,10 @@ write_files:
         --accept-host-key
         --limit 127.0.0.1
         --extra-vars "gcp_batch_service_account_email=${GCP_BATCH_SERVICE_ACCOUNT_EMAIL}"
+        --extra-vars "terra_workspace=${TERRA_WORKSPACE}"
+        --extra-vars "terra_namespace=${TERRA_NAMESPACE}"
+        --extra-vars "terra_drs_url=${TERRA_DRS_URL}"
+        --extra-vars "terra_api_url=${TERRA_API_URL}"
       )
 
       if [ "$RESTORE_GALAXY" = "true" ]; then

--- a/roles/galaxy_k8s_deployment/defaults/main.yml
+++ b/roles/galaxy_k8s_deployment/defaults/main.yml
@@ -94,9 +94,9 @@ ingress_version: "4.13.2"  # https://github.com/kubernetes/ingress-nginx?tab=rea
 
 # Galaxy Application Configuration
 use_local_chart: false
-galaxy_prefix: "/"
+galaxy_prefix: "/galaxy"
 galaxy_chart: cloudve/galaxy
-galaxy_chart_version: "6.8.1"
+galaxy_chart_version: "6.8.2"
 galaxy_deps_chart: cloudve/galaxy-deps
 galaxy_deps_version: "1.1.1"
 
@@ -135,6 +135,13 @@ gcp_batch_service_account_email: ""
 # An explicit value is never overridden by detection. When this is empty and
 # detection fails, the region in the Helm values files is used unchanged.
 gcp_batch_region: ""
+
+# Terra / AnVIL launch context
+# Supplied at VM launch time by the orchestrating service (e.g. Leonardo).
+terra_workspace: ""
+terra_namespace: ""
+terra_drs_url: ""
+terra_api_url: ""
 
 # Pulsar Application Configuration
 pulsar_chart: cloudve/pulsar

--- a/roles/galaxy_k8s_deployment/defaults/main.yml
+++ b/roles/galaxy_k8s_deployment/defaults/main.yml
@@ -91,6 +91,17 @@ restore_galaxy: false
 
 # Ingress Configuration
 ingress_version: "4.13.2"  # https://github.com/kubernetes/ingress-nginx?tab=readme-ov-file#supported-versions-table
+# Pass the caller's `X-Forwarded-*` headers through to backends instead of
+# overwriting them from the controller's own connection. Enable this only when an
+# external L7 proxy terminates TLS and every request arrives through it, as with
+# Leonardo on Terra: there, the controller would otherwise stamp
+# `X-Forwarded-Proto: http`, so tusd hands the browser an `http://` upload URL
+# that is then blocked as mixed content on an `https://` page.
+# Off by default because it makes the controller trust caller-supplied
+# `X-Forwarded-*`. On a directly reachable VM that lets anyone forge the scheme,
+# host, and client IP seen by Galaxy. When enabling, also narrow
+# `proxy-real-ip-cidr` (default `0.0.0.0/0`) to the proxy to bound the trust.
+ingress_use_forwarded_headers: false
 
 # Galaxy Application Configuration
 use_local_chart: false

--- a/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
+++ b/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
@@ -465,17 +465,17 @@
 # job_conf.yml is mounted with subPath, and Kubernetes never propagates ConfigMap
 # updates into subPath mounts; every deployment that mounts it keeps the config it
 # started with until it is restarted.
-# The deployments to restart are listed explicitly in galaxy_job_conf_deployments
-# below; update that list if the chart adds or renames handlers. The guard task
-# fails the play when a job handler exists in the cluster but is missing from the
-# list, so an omission cannot silently leave a handler running on stale config.
-- name: Restart Galaxy deployments and wait for them to pick up configuration changes
+# Only job handlers need the new config: gcp_batch_volumes is a runner-plugin
+# setting, and Galaxy instantiates runner plugins solely in processes where
+# app.is_job_handler is true (galaxy.jobs.manager.JobManager.start). The web and
+# workflow-scheduler pods attach to no handler pool, so their copy of job_conf.yml
+# is never read by a runner and restarting them only lengthens the deployment.
+- name: Restart Galaxy job handlers and wait for them to pick up configuration changes
   vars:
-    galaxy_job_conf_deployments:
-      - galaxy-web
-      - galaxy-workflow
-      - galaxy-job-0
     galaxy_job_handler_pattern: '^galaxy-job-[0-9]+$'
+    galaxy_job_handler_deployments: >-
+      {{ galaxy_deployments.resources | default([]) | map(attribute='metadata.name')
+         | select('match', galaxy_job_handler_pattern) | list }}
   when:
     - enable_gcp_batch | default(false) | bool
     - nfs_export_path is defined
@@ -488,33 +488,33 @@
         kubeconfig: "{{ kubeconfig_path }}"
       register: galaxy_deployments
 
-    - name: Fail if a job handler is missing from the restart list
-      vars:
-        cluster_job_handlers: >-
-          {{ galaxy_deployments.resources | map(attribute='metadata.name')
-             | select('match', galaxy_job_handler_pattern) | list }}
+    # Matching nothing would silently skip the restart and leave every handler on a
+    # job_conf.yml without gcp_batch_volumes, failing every Batch job. Fail instead,
+    # so a chart that renames its handler deployments is caught here.
+    - name: Fail if no job handler deployments were found
       fail:
         msg: >-
-          Job handler(s)
-          {{ cluster_job_handlers | difference(galaxy_job_conf_deployments) | join(', ') }}
-          exist in the galaxy namespace but are missing from
-          galaxy_job_conf_deployments. They would keep a stale job_conf.yml and every
-          GCP Batch job they dispatch would fail. Add them to the list in this file.
-      when: cluster_job_handlers | difference(galaxy_job_conf_deployments) | length > 0
+          No deployment in the galaxy namespace matches
+          {{ galaxy_job_handler_pattern }}. Found:
+          {{ galaxy_deployments.resources | map(attribute='metadata.name') | join(', ') }}.
+          Update galaxy_job_handler_pattern to match the chart's job handler
+          deployments, otherwise they keep a stale job_conf.yml and every GCP Batch
+          job they dispatch would fail.
+      when: galaxy_job_handler_deployments | length == 0
 
-    - name: Restart Galaxy deployments to pick up configuration changes
+    - name: Restart Galaxy job handlers to pick up configuration changes
       shell: kubectl rollout restart deployment {{ item }} -n galaxy
       environment:
         KUBECONFIG: "{{ kubeconfig_path }}"
-      loop: "{{ galaxy_job_conf_deployments }}"
+      loop: "{{ galaxy_job_handler_deployments }}"
 
-    - name: Wait for restarted deployments to finish rolling out
+    - name: Wait for restarted job handlers to finish rolling out
       # 30 minutes per deployment; first-boot rollouts are slow while Galaxy builds
       # the tool panel and the CVMFS caches warm up.
       shell: kubectl rollout status deployment {{ item }} -n galaxy --timeout=1800s
       environment:
         KUBECONFIG: "{{ kubeconfig_path }}"
-      loop: "{{ galaxy_job_conf_deployments }}"
+      loop: "{{ galaxy_job_handler_deployments }}"
       changed_when: false
 
     # Fail loudly rather than leaving a cluster that looks healthy but errors every
@@ -528,5 +528,5 @@
         /galaxy/server/config/job_conf.yml
       environment:
         KUBECONFIG: "{{ kubeconfig_path }}"
-      loop: "{{ galaxy_job_conf_deployments | select('match', galaxy_job_handler_pattern) | list }}"
+      loop: "{{ galaxy_job_handler_deployments }}"
       changed_when: false

--- a/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
+++ b/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
@@ -355,6 +355,12 @@
         size: "{{ galaxy_persistence_size }}"
       postgresql:
         galaxyDatabasePassword: "{{ galaxy_db_password }}"
+      terra:
+        launch:
+          workspace: "{{ terra_workspace | default('') }}"
+          namespace: "{{ terra_namespace | default('') }}"
+          drsURL: "{{ terra_drs_url | default('') }}"
+          apiURL: "{{ terra_api_url | default('') }}"
       configs:
         galaxy.yml:
           galaxy:

--- a/roles/galaxy_k8s_deployment/tasks/ingress_setup.yml
+++ b/roles/galaxy_k8s_deployment/tasks/ingress_setup.yml
@@ -33,6 +33,7 @@
         watchIngressWithoutClass: true
         config:
           proxy-body-size: "100G"
+          use-forwarded-headers: "{{ ingress_use_forwarded_headers | bool | lower }}"
 
 - name: "Fix for issue https://github.com/kubernetes/ingress-nginx/issues/5401"
   kubernetes.core.k8s:


### PR DESCRIPTION
Brings the current `dev` into `anvil`, which is the branch Leonardo pulls from (`ansible-pull -C anvil`). Two substantive changes, both needed for the Terra deployment.

## #78 — Terra workspace linking

Adds `terra_workspace` / `terra_namespace` / `terra_drs_url` / `terra_api_url`, plumbed from `user_data.sh` through to the Galaxy Helm values so a launched instance can point at the workspace it belongs to. Also narrows the post-GCP-Batch-config restart to just the job handlers instead of every deployment.

## #80 — Forwarded header support

Adds `ingress_use_forwarded_headers` (default `false`), settable via the `ingress_use_forwarded_headers` instance-metadata attribute.

This is the last piece of the resumable-upload fix. Without it ingress-nginx ignores Leonardo's `X-Forwarded-*` headers and refills them from its own plaintext connection, so tusd hands the browser an `http://` upload URL that then gets blocked as mixed content on an `https://` page. Verified on a live cluster: with the setting off, forwarded headers are discarded and the TUS `Location` comes back as `http://<internal-host>/...`; with it on, the same request yields `https://<external-host>/...`. It corrects the host as well as the scheme — both were being overwritten by the same mechanism.

Left off by default because it makes the controller trust caller-supplied `X-Forwarded-*`, which is only safe behind a trusted proxy. Leonardo opts in per-VM, so no anvil-specific diff is needed. On a directly reachable dev VM the default keeps the current behaviour.

Note this depends on two upstream fixes to land for uploads to work end to end: the Galaxy TUS router prefix fix (galaxyproject/galaxy#23224) and the chart's tusd routing fixes (galaxyproject/galaxy-helm#549).

## Merge safety

Clean merge, no conflicts. `bin/launch_vm.sh` — the anvil-specific `GALAXY_CHART_VERSION` and `GIT_BRANCH=anvil` pins — is not touched by any of these commits, so anvil's customisation is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
