### PR TITLE
Parameterize the GCP project id for the Batch runner (Terra-injectable)

### DIFF
--- a/bin/launch_vm.sh
+++ b/bin/launch_vm.sh
@@ -22,6 +22,10 @@ PROJECT="anvil-and-terra-development"
 VM_USER="debian"
 ZONE="us-east4-c"
 RESTORE_GALAXY=false
+# GCP project for the Batch runner (gcp_project_id). Empty -> the playbook auto-detects
+# it from the VM's metadata (the VM's own project). Set to override, e.g. Batch in a
+# different project than the VM.
+GCP_PROJECT_ID=""
 
 # Parse command line arguments
 DISK_NAME=""
@@ -53,7 +57,9 @@ Options:
   -k, --ssh-key SSH_KEY             SSH public key for VM user (required)
   -u, --user USER                   VM user account name (default: $VM_USER)
   -m, --machine-type TYPE           Machine type (default: $MACHINE_TYPE)
-  -p, --project PROJECT             GCP project ID (default: $PROJECT)
+  -p, --project PROJECT             GCP project ID for the VM (default: $PROJECT)
+  --gcp-project-id PROJECT          GCP project for the Batch runner (gcp_project_id).
+                                    Empty -> auto-detected from the VM's metadata.
   -r, --git-repo REPO               Git repository URL (default: $GIT_REPO)
   -s, --disk-size SIZE              Size of NFS persistent disk (default: $DISK_SIZE)
   -z, --zone ZONE                   GCP zone (default: $ZONE)
@@ -163,6 +169,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         -p|--project)
             PROJECT="$2"
+            shift 2
+            ;;
+        --gcp-project-id)
+            GCP_PROJECT_ID="$2"
             shift 2
             ;;
         -r|--git-repo)
@@ -446,6 +456,7 @@ cat >> "$TEMP_USER_DATA" << EOF
     GALAXY_VALUES_FILES_JSON='${GALAXY_VALUES_FILES_JSON}'
     GALAXY_IMPORT_PROFILE_JSON='${GALAXY_IMPORT_PROFILE_JSON}'
     RESTORE_GALAXY="${RESTORE_GALAXY}"
+    GCP_PROJECT_ID="${GCP_PROJECT_ID}"
 EOF
 
 cat >> "$TEMP_USER_DATA" << 'EOF'
@@ -482,6 +493,11 @@ cat >> "$TEMP_USER_DATA" << 'EOF'
     EXTRA_VARS="{\"enable_gcp_batch\": true, \"galaxy_chart\": \"${GALAXY_CHART}\", \"galaxy_chart_version\": \"${GALAXY_CHART_VERSION}\", \"galaxy_deps_chart\": \"${GALAXY_DEPS_CHART}\", \"galaxy_deps_version\": \"${GALAXY_DEPS_VERSION}\", \"galaxy_values_files\": ${GALAXY_VALUES_FILES_JSON}"
     if [ -n "${GALAXY_IMPORT_PROFILE_JSON}" ]; then
         EXTRA_VARS="${EXTRA_VARS}, \"galaxy_import_profile\": ${GALAXY_IMPORT_PROFILE_JSON}"
+    fi
+    # Only pass gcp_project_id when --gcp-project-id was supplied; empty lets the
+    # playbook auto-detect the project from the VM's metadata.
+    if [ -n "${GCP_PROJECT_ID}" ]; then
+        EXTRA_VARS="${EXTRA_VARS}, \"gcp_project_id\": \"${GCP_PROJECT_ID}\""
     fi
     EXTRA_VARS="${EXTRA_VARS}}"
 

--- a/bin/user_data.sh
+++ b/bin/user_data.sh
@@ -83,8 +83,19 @@ write_files:
       # Add restore_galaxy if enabled
       RESTORE_GALAXY=$(curl -s -f "http://metadata.google.internal/computeMetadata/v1/instance/attributes/restore_galaxy" -H "Metadata-Flavor: Google" 2>/dev/null || echo "false")
 
-      GCP_BATCH_SERVICE_ACCOUNT_EMAIL=$(curl -s -f "http://metadata.google.internal/computeMetadata/v1/instance/attributes/gcp_batch_service_account_email" -H "Metadata-Flavor: Google" 2>/dev/null || echo "galaxy-batch-runner@anvil-and-terra-development.iam.gserviceaccount.com")
-      echo "[$(date)] - GCP Batch service account email: ${GCP_BATCH_SERVICE_ACCOUNT_EMAIL}"
+      # GCP project for the Batch runner. Empty -> the playbook auto-detects it from the
+      # VM metadata (project/project-id). Set the gcp_project_id instance attribute
+      # (from Leonardo/Terra) to target a different project.
+      GCP_PROJECT_ID=$(curl -s -f "http://metadata.google.internal/computeMetadata/v1/instance/attributes/gcp_project_id" -H "Metadata-Flavor: Google" 2>/dev/null || echo "")
+      echo "[$(date)] - GCP project id (empty = auto-detect): ${GCP_PROJECT_ID}"
+
+      # Empty -> the playbook derives galaxy-batch-runner@<gcp_project_id>... so the
+      # service account follows the project instead of being pinned to one.
+      GCP_BATCH_SERVICE_ACCOUNT_EMAIL=$(curl -s -f "http://metadata.google.internal/computeMetadata/v1/instance/attributes/gcp_batch_service_account_email" -H "Metadata-Flavor: Google" 2>/dev/null || echo "")
+      echo "[$(date)] - GCP Batch service account email (empty = derive from project): ${GCP_BATCH_SERVICE_ACCOUNT_EMAIL}"
+
+      # Optional override of the Batch VM image name; empty -> the role default.
+      GCP_BATCH_VM_IMAGE=$(curl -s -f "http://metadata.google.internal/computeMetadata/v1/instance/attributes/gcp_batch_vm_image" -H "Metadata-Flavor: Google" 2>/dev/null || echo "")
 
       # Set this to "true" only when an external L7 proxy terminates TLS and is the
       # only way in (e.g. Leonardo on Terra). It makes ingress-nginx trust the
@@ -113,6 +124,7 @@ write_files:
         -i /tmp/ansible-inventory/localhost
         --accept-host-key
         --limit 127.0.0.1
+        --extra-vars "gcp_project_id=${GCP_PROJECT_ID}"
         --extra-vars "gcp_batch_service_account_email=${GCP_BATCH_SERVICE_ACCOUNT_EMAIL}"
         --extra-vars "terra_workspace=${TERRA_WORKSPACE}"
         --extra-vars "terra_namespace=${TERRA_NAMESPACE}"
@@ -120,6 +132,11 @@ write_files:
         --extra-vars "terra_api_url=${TERRA_API_URL}"
         --extra-vars "ingress_use_forwarded_headers=${INGRESS_USE_FORWARDED_HEADERS}"
       )
+
+      # Only override the Batch VM image when set; empty leaves the role default.
+      if [ -n "${GCP_BATCH_VM_IMAGE}" ]; then
+          PULL_ARGS+=(--extra-vars "gcp_batch_vm_image=${GCP_BATCH_VM_IMAGE}")
+      fi
 
       if [ "$RESTORE_GALAXY" = "true" ]; then
           PULL_ARGS+=(--extra-vars "restore_galaxy=true")

--- a/roles/galaxy_k8s_deployment/defaults/main.yml
+++ b/roles/galaxy_k8s_deployment/defaults/main.yml
@@ -141,6 +141,16 @@ galaxy_job_max_mem: 4
 #   - Update job_conf.yml with GCP Batch runner configuration
 #   - Restart Galaxy deployments to apply changes
 enable_gcp_batch: true
+# GCP project that owns the Batch runner's project_id, service account, and custom VM
+# image. Empty -> auto-detected from the VM's own metadata server, so a Terra-launched
+# VM uses its project; Terra (or any launcher) may inject it explicitly, e.g.
+# -e gcp_project_id=my-project. The playbook injects it into the gcp_batch runner config
+# so the value is NOT hardcoded in values/values.yml.
+gcp_project_id: ""
+# Name of the custom Batch VM image (CVMFS pre-configured) in gcp_project_id.
+gcp_batch_vm_image: "galaxy-k8s-boot-v2026-06-30"
+# Service account the Batch runner uses. Empty -> derived as
+# galaxy-batch-runner@<gcp_project_id>.iam.gserviceaccount.com.
 gcp_batch_service_account_email: ""
 # Leave empty to derive the region from the VM's own zone via the metadata server.
 # An explicit value is never overridden by detection. When this is empty and

--- a/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
+++ b/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
@@ -334,6 +334,42 @@
     - enable_gcp_batch | default(false) | bool
     - gcp_batch_region | default('') | length == 0
 
+# The gcp_batch runner's project_id / service account / custom VM image all live in one
+# GCP project. Auto-detect it from the VM's own metadata (so a Terra VM uses its own
+# project) unless gcp_project_id was set explicitly (e.g. injected by Terra).
+- name: Detect the GCP project id from the metadata server
+  ansible.builtin.uri:
+    url: http://metadata.google.internal/computeMetadata/v1/project/project-id
+    headers:
+      Metadata-Flavor: Google
+    return_content: true
+    timeout: 5
+  register: gcp_project_meta
+  failed_when: false
+  when:
+    - enable_gcp_batch | default(false) | bool
+    - gcp_project_id | default('') | length == 0
+
+- name: Set gcp_project_id from the detected project
+  set_fact:
+    gcp_project_id: "{{ gcp_project_meta.content | default('') | trim }}"
+  when:
+    - enable_gcp_batch | default(false) | bool
+    - gcp_project_id | default('') | length == 0
+    - gcp_project_meta.status | default(0) == 200
+    - (gcp_project_meta.content | default('') | trim) | length > 0
+
+- name: Fail if the GCP project id is unknown
+  fail:
+    msg: >-
+      enable_gcp_batch is true but gcp_project_id is empty and could not be detected
+      from the metadata server (HTTP status {{ gcp_project_meta.status | default('n/a') }}).
+      The gcp_batch runner needs a project. Set gcp_project_id explicitly
+      (-e gcp_project_id=<project>).
+  when:
+    - enable_gcp_batch | default(false) | bool
+    - gcp_project_id | default('') | length == 0
+
 - name: Helm install Galaxy
   kubernetes.core.helm:
     name: galaxy
@@ -344,7 +380,7 @@
     update_repo_cache: "{{ not (use_local_chart | default(false) | bool) }}"
     timeout: "20m0s"
     values_files: "{{ lookup('sequence', 'start=0 end=' ~ (_galaxy_values_files|length - 1) ~ ' format=/tmp/galaxy_values_%d.yml', wantlist=True) }}"
-    values: "{{ _helm_values_base | combine(_helm_values_gcp_batch if (enable_gcp_batch | default(false) | bool and gcp_batch_region | default('') | length > 0) else {}, recursive=True) | combine(_helm_values_cnpg_plugin if (restore_galaxy and detected_galaxy_pvc_uuid | default('') != '') else {}, recursive=True) }}"
+    values: "{{ _helm_values_base | combine(_helm_values_gcp_project if (enable_gcp_batch | default(false) | bool and gcp_project_id | default('') | length > 0) else {}, recursive=True) | combine(_helm_values_gcp_batch if (enable_gcp_batch | default(false) | bool and gcp_batch_region | default('') | length > 0) else {}, recursive=True) | combine(_helm_values_cnpg_plugin if (restore_galaxy and detected_galaxy_pvc_uuid | default('') != '') else {}, recursive=True) }}"
     set_values: "{{ galaxy_helm_extra_sets | default([]) + _helm_prefix_sets }}"
   vars:
     _helm_prefix_sets:
@@ -382,6 +418,17 @@
           runners:
             gcp_batch:
               region: "{{ gcp_batch_region }}"
+    # Inject the GCP-project-specific gcp_batch settings (deep-merges over the runner
+    # block in the values files) so the project is not hardcoded in values/values.yml.
+    # The service account defaults to galaxy-batch-runner@<project> unless overridden.
+    _helm_values_gcp_project:
+      configs:
+        job_conf.yml:
+          runners:
+            gcp_batch:
+              project_id: "{{ gcp_project_id }}"
+              service_account_email: "{{ gcp_batch_service_account_email if (gcp_batch_service_account_email | default('') | length > 0) else ('galaxy-batch-runner@' ~ gcp_project_id ~ '.iam.gserviceaccount.com') }}"
+              custom_vm_image: "projects/{{ gcp_project_id }}/global/images/{{ gcp_batch_vm_image }}"
     _helm_values_cnpg_plugin:
       postgresql:
         cluster:

--- a/values/values.yml
+++ b/values/values.yml
@@ -69,12 +69,12 @@ configs:
       gcp_batch:
         load: galaxy.jobs.runners.gcp_batch:GoogleCloudBatchJobRunner
         workers: 4
-        # Basic GCP settings
-        project_id: anvil-and-terra-development
+        # project_id, service_account_email, and custom_vm_image are injected by the
+        # playbook from gcp_project_id (auto-detected from the VM metadata, or set by
+        # Terra at launch), so the GCP project is not hardcoded here.
         # Overridden by the region derived from the VM's zone, or by an explicit
         # gcp_batch_region, when enable_gcp_batch is set
         region: us-east4
-        service_account_email: galaxy-batch-runner@anvil-and-terra-development.iam.gserviceaccount.com
 
         # Network configuration (required for NFS access)
         network: default
@@ -94,8 +94,8 @@ configs:
         galaxy_group_id: 10001
         docker_extra_volumes: "/cvmfs/data.galaxyproject.org:/cvmfs/data.galaxyproject.org:ro,/cvmfs/cloud.galaxyproject.org:/cvmfs/cloud.galaxyproject.org:ro"
 
-        # Custom VM image with CVMFS pre-configured (update date as needed)
-        custom_vm_image: projects/anvil-and-terra-development/global/images/galaxy-k8s-boot-v2026-06-30
+        # custom_vm_image (projects/<gcp_project_id>/global/images/<gcp_batch_vm_image>)
+        # is injected by the playbook; update gcp_batch_vm_image to change the image.
         # Job execution settings
         max_retry_count: 3
         # Max time a job will run before being deleted. Must be in seconds (end with 's'). Default 24hrs.


### PR DESCRIPTION
## What

The `project_id`, `service_account_email`, and `custom_vm_image` were hardcoded in `values/values.yml` for the GCP Batch runner. This PR makes these project values injectable Ansible variables so Terra (or any launcher) can set it per instance instead of it being pinned to one project.

## Changes

- **`gcp_project_id`** if left empty (default) the project id is auto-detected from the VM's own metadata server*, so a Terra-launched VM uses its own project. Override explicitly with `-e gcp_project_id=<project>`.
- **`gcp_batch_vm_image`** variable for the Batch VM image name.
- **`gcp_batch_service_account_email`** if not specified the service account email used for Batch jobs will be derived from the project id as : `galaxy-batch-runner@<project>.iam.gserviceaccount.com`
- **`values/values.yml`** remove add references (three) to  `anvil-and-terra-development`
- **`bin/launch_vm.sh`**: new `--gcp-project-id` flag (empty by default).

## Resolution order (project id)

`--gcp-project-id` / `-e gcp_project_id=…` (explicit) → metadata auto-detect (the VM's own project) → fail-fast.

## Validation

`ansible-playbook --syntax-check` passes; YAML lint of the changed files passes; `bash -n bin/launch_vm.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)