### PR TITLE
Set quota to PVC size

### DIFF
--- a/roles/galaxy_k8s_deployment/defaults/main.yml
+++ b/roles/galaxy_k8s_deployment/defaults/main.yml
@@ -122,6 +122,22 @@ galaxy_values_files:
 # Keep it less than or equal to the usable space behind `nfs_size`, and
 # leave headroom if other PVCs also use the `nfs` storage class.
 galaxy_persistence_size: "115Gi"
+
+# Default disk quota for registered users, so Galaxy's storage dashboard shows a
+# limit instead of "unlimited" on a VM whose disk is a fixed size. `enable_quotas`
+# in the Helm values only switches on enforcement; the amount is a database record
+# with no galaxy.yml equivalent, so the playbook creates it through the API.
+galaxy_set_user_quota: true
+# Percentage of `galaxy_persistence_size` to grant. Deliberately below 100: a quota
+# counts only user dataset usage, while the same volume also holds tmp, the tus
+# upload store, and the CVMFS cache.
+galaxy_user_quota_percent: 90
+# Set to pin an explicit amount and ignore the percentage. Must be a size Galaxy can
+# parse -- Kubernetes-style units are rejected (`115Gi` fails, `115 GiB` works), which
+# is why the derived value appends the missing `B`. `unlimited` is also accepted.
+galaxy_user_quota: ""
+galaxy_user_quota_name: "vm-disk-quota"
+
 galaxy_db_password: "galaxydbpassword"
 galaxy_user: "default-user@galaxyproject.org"
 galaxy_bootstrap_api_key: "galaxypassword"

--- a/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
+++ b/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
@@ -583,3 +583,86 @@
         KUBECONFIG: "{{ kubeconfig_path }}"
       loop: "{{ galaxy_job_handler_deployments }}"
       changed_when: false
+
+# ============================================================================
+# Default user disk quota
+# ============================================================================
+# `enable_quotas` in the Helm values only switches quota enforcement on. The amount
+# itself is a database record with no galaxy.yml equivalent, so it has to be created
+# through the API once Galaxy is serving. Without it the storage dashboard reports
+# "unlimited", which is misleading on a VM backed by a fixed-size disk.
+- name: Configure the default user disk quota
+  vars:
+    # ingress-nginx runs with hostNetwork, so the VM reaches Galaxy on its own port 80.
+    _gxy_api: "http://127.0.0.1{{ galaxy_prefix | regex_replace('/$', '') }}"
+    _pvc_num: "{{ galaxy_persistence_size | regex_replace('^([0-9.]+).*$', '\\1') }}"
+    _pvc_unit: "{{ galaxy_persistence_size | regex_replace('^[0-9.]+\\s*', '') }}"
+    # Galaxy's parser wants GiB/MiB where Kubernetes writes Gi/Mi.
+    _gxy_unit: "{{ _pvc_unit if _pvc_unit.endswith('B') else _pvc_unit ~ 'B' }}"
+    # Single backslash: this is a folded scalar, where YAML leaves backslashes literal
+    # (unlike the double-quoted scalars above, which need `\\s`).
+    _derived_quota: >-
+      {{ ((_pvc_num | float) * (galaxy_user_quota_percent | float) / 100) | round(1) ~ ' ' ~ _gxy_unit
+         if galaxy_persistence_size is match('^[0-9.]+\s*[KMGTP]i?B?$') else '' }}
+    _quota_amount: "{{ galaxy_user_quota | default('', true) | ternary(galaxy_user_quota, _derived_quota) | trim }}"
+    # Evaluated lazily, so referencing the register from an earlier block task is safe.
+    _existing_quota: "{{ (_gxy_quotas.json | default([])) | selectattr('name', 'equalto', galaxy_user_quota_name) | list }}"
+  when:
+    - deploy_galaxy | default(true) | bool
+    - galaxy_set_user_quota | default(true) | bool
+    - _quota_amount | length > 0
+  block:
+    - name: Wait for the Galaxy API before setting the quota
+      ansible.builtin.uri:
+        url: "{{ _gxy_api }}/api/version"
+        timeout: 10
+      register: _gxy_version
+      until: _gxy_version.status | default(0) == 200
+      retries: 30
+      delay: 10
+      changed_when: false
+
+    - name: Look up the existing default user quota
+      ansible.builtin.uri:
+        url: "{{ _gxy_api }}/api/quotas"
+        headers:
+          x-api-key: "{{ galaxy_bootstrap_api_key }}"
+        timeout: 30
+      register: _gxy_quotas
+      changed_when: false
+
+    - name: Create the default user quota
+      ansible.builtin.uri:
+        url: "{{ _gxy_api }}/api/quotas"
+        method: POST
+        headers:
+          x-api-key: "{{ galaxy_bootstrap_api_key }}"
+        body_format: json
+        body:
+          name: "{{ galaxy_user_quota_name }}"
+          description: "Default quota for registered users, managed by galaxy-k8s-boot"
+          amount: "{{ _quota_amount }}"
+          operation: "="
+          default: registered
+        status_code: [200, 201]
+        timeout: 30
+      when: _existing_quota | length == 0
+
+    # Keep an existing quota in step with the current disk size, so relaunching onto a
+    # resized volume does not leave the dashboard reporting the old limit.
+    - name: Update the existing default user quota
+      ansible.builtin.uri:
+        url: "{{ _gxy_api }}/api/quotas/{{ _existing_quota[0].id }}"
+        method: PUT
+        headers:
+          x-api-key: "{{ galaxy_bootstrap_api_key }}"
+        body_format: json
+        body:
+          amount: "{{ _quota_amount }}"
+        status_code: [200, 201, 204]
+        timeout: 30
+      when: _existing_quota | length > 0
+
+    - name: Display the configured quota
+      debug:
+        msg: "Default user disk quota: {{ _quota_amount }} (from {{ 'galaxy_user_quota' if galaxy_user_quota | length > 0 else galaxy_user_quota_percent ~ '% of ' ~ galaxy_persistence_size }})"


### PR DESCRIPTION
By default, the user sees 'unlimited' as the amount of available storage, which is not quite the case. This PR is aimed primarily at the single-user, Anvil deployments by simply setting the quota to the size of the PVC. This may not be desirable in a multi-tenant deployment of Galaxy, but it can easily be disabled. 