### PR TITLE
Terra infra fixes

### DIFF
--- a/bin/user_data.sh
+++ b/bin/user_data.sh
@@ -97,6 +97,13 @@ write_files:
       # Optional override of the Batch VM image name; empty -> the role default.
       GCP_BATCH_VM_IMAGE=$(curl -s -f "http://metadata.google.internal/computeMetadata/v1/instance/attributes/gcp_batch_vm_image" -H "Metadata-Flavor: Google" 2>/dev/null || echo "")
 
+      # VPC network / subnet the Batch VMs join. Leonardo injects these so Batch VMs
+      # land in the same project VPC as the Galaxy VM and can reach NFS. Empty -> the
+      # value in the Helm values files is used unchanged.
+      GCP_BATCH_NETWORK=$(curl -s -f "http://metadata.google.internal/computeMetadata/v1/instance/attributes/gcp-network" -H "Metadata-Flavor: Google" 2>/dev/null || echo "")
+      GCP_BATCH_SUBNET=$(curl -s -f "http://metadata.google.internal/computeMetadata/v1/instance/attributes/gcp-subnet" -H "Metadata-Flavor: Google" 2>/dev/null || echo "")
+      echo "[$(date)] - GCP Batch network/subnet (empty = values default): ${GCP_BATCH_NETWORK}/${GCP_BATCH_SUBNET}"
+
       # Set this to "true" only when an external L7 proxy terminates TLS and is the
       # only way in (e.g. Leonardo on Terra). It makes ingress-nginx trust the
       # caller-supplied X-Forwarded-* headers, which is what lets tusd generate
@@ -126,6 +133,8 @@ write_files:
         --limit 127.0.0.1
         --extra-vars "gcp_project_id=${GCP_PROJECT_ID}"
         --extra-vars "gcp_batch_service_account_email=${GCP_BATCH_SERVICE_ACCOUNT_EMAIL}"
+        --extra-vars "gcp_batch_network=${GCP_BATCH_NETWORK}"
+        --extra-vars "gcp_batch_subnet=${GCP_BATCH_SUBNET}"
         --extra-vars "terra_workspace=${TERRA_WORKSPACE}"
         --extra-vars "terra_namespace=${TERRA_NAMESPACE}"
         --extra-vars "terra_drs_url=${TERRA_DRS_URL}"

--- a/roles/galaxy_k8s_deployment/defaults/main.yml
+++ b/roles/galaxy_k8s_deployment/defaults/main.yml
@@ -141,6 +141,10 @@ galaxy_user_quota_name: "vm-disk-quota"
 galaxy_db_password: "galaxydbpassword"
 galaxy_user: "default-user@galaxyproject.org"
 galaxy_bootstrap_api_key: "galaxypassword"
+# Public HTTPS URL Galaxy uses to build absolute links (history exports, API
+# callbacks). Leonardo passes this in so Galaxy emits https:// links; empty ->
+# omitted from galaxy.yml so Galaxy derives it from the request.
+galaxy_infrastructure_url: ""
 # Profile values file(s) to pass to galaxy-helm's postInstallJob.imports.
 # Set to [] to disable post-install imports entirely.
 galaxy_import_profile:

--- a/roles/galaxy_k8s_deployment/defaults/main.yml
+++ b/roles/galaxy_k8s_deployment/defaults/main.yml
@@ -176,6 +176,11 @@ gcp_batch_service_account_email: ""
 # An explicit value is never overridden by detection. When this is empty and
 # detection fails, the region in the Helm values files is used unchanged.
 gcp_batch_region: ""
+# VPC network / subnet the Batch VMs join. Leonardo injects these so Batch VMs
+# land in the same (often non-default) project VPC as the Galaxy VM and can reach
+# the NFS server. Empty -> the value in the Helm values files is used unchanged.
+gcp_batch_network: ""
+gcp_batch_subnet: ""
 
 # Terra / AnVIL launch context
 # Supplied at VM launch time by the orchestrating service (e.g. Leonardo).

--- a/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
+++ b/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
@@ -401,6 +401,11 @@
         galaxy.yml:
           galaxy:
             bootstrap_admin_api_key: "{{ galaxy_bootstrap_api_key | default(omit) }}"
+            # Leonardo passes the public HTTPS URL so Galaxy emits https:// links.
+            # Empty -> omit the key entirely (omit only fires on falsy with the 2nd
+            # arg): Galaxy keeps its default and derives the URL from the request.
+            # Setting it to "" would mark it "set" and disable that derivation.
+            galaxy_infrastructure_url: "{{ galaxy_infrastructure_url | default(omit, true) }}"
       jobs:
         rules:
           tpv_rules_local.yml:

--- a/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
+++ b/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
@@ -380,7 +380,7 @@
     update_repo_cache: "{{ not (use_local_chart | default(false) | bool) }}"
     timeout: "20m0s"
     values_files: "{{ lookup('sequence', 'start=0 end=' ~ (_galaxy_values_files|length - 1) ~ ' format=/tmp/galaxy_values_%d.yml', wantlist=True) }}"
-    values: "{{ _helm_values_base | combine(_helm_values_gcp_project if (enable_gcp_batch | default(false) | bool and gcp_project_id | default('') | length > 0) else {}, recursive=True) | combine(_helm_values_gcp_batch if (enable_gcp_batch | default(false) | bool and gcp_batch_region | default('') | length > 0) else {}, recursive=True) | combine(_helm_values_cnpg_plugin if (restore_galaxy and detected_galaxy_pvc_uuid | default('') != '') else {}, recursive=True) }}"
+    values: "{{ _helm_values_base | combine(_helm_values_gcp_project if (enable_gcp_batch | default(false) | bool and gcp_project_id | default('') | length > 0) else {}, recursive=True) | combine(_helm_values_gcp_batch if (enable_gcp_batch | default(false) | bool and gcp_batch_region | default('') | length > 0) else {}, recursive=True) | combine(_helm_values_gcp_network if (enable_gcp_batch | default(false) | bool and gcp_batch_network | default('') | length > 0) else {}, recursive=True) | combine(_helm_values_gcp_subnet if (enable_gcp_batch | default(false) | bool and gcp_batch_subnet | default('') | length > 0) else {}, recursive=True) | combine(_helm_values_cnpg_plugin if (restore_galaxy and detected_galaxy_pvc_uuid | default('') != '') else {}, recursive=True) }}"
     set_values: "{{ galaxy_helm_extra_sets | default([]) + _helm_prefix_sets }}"
   vars:
     _helm_prefix_sets:
@@ -434,6 +434,23 @@
               project_id: "{{ gcp_project_id }}"
               service_account_email: "{{ gcp_batch_service_account_email if (gcp_batch_service_account_email | default('') | length > 0) else ('galaxy-batch-runner@' ~ gcp_project_id ~ '.iam.gserviceaccount.com') }}"
               custom_vm_image: "projects/{{ gcp_project_id }}/global/images/{{ gcp_batch_vm_image }}"
+    # Inject the Batch VPC network/subnet (deep-merges over the runner block in the
+    # values files) so Batch VMs join the same project VPC as the Galaxy VM and can
+    # reach NFS. Kept as two single-key blocks, each combined only when its value is
+    # set, so an unset one leaves the values-file default untouched (an omit here would
+    # instead delete the base key during the merge).
+    _helm_values_gcp_network:
+      configs:
+        job_conf.yml:
+          runners:
+            gcp_batch:
+              network: "{{ gcp_batch_network }}"
+    _helm_values_gcp_subnet:
+      configs:
+        job_conf.yml:
+          runners:
+            gcp_batch:
+              subnet: "{{ gcp_batch_subnet }}"
     _helm_values_cnpg_plugin:
       postgresql:
         cluster:


### PR DESCRIPTION
Allows Terra to inject:
- `galaxy_infrastructure_url` so Galaxy will emit https URLs
- the VPC net and subnet Batch VMs should use
