### PR TITLE
Auto-detect and log gcp_batch network/subnet from VM metadata

### DIFF
--- a/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
+++ b/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
@@ -375,7 +375,12 @@
 # it here in the role (not just bin/user_data.sh) means it works regardless of the
 # bootstrap/startup script that launched the VM. Absent -> left empty so the value in
 # the Helm values files is used unchanged.
-- name: Detect the Batch network from the instance metadata
+#
+# The probes run unconditionally (only gated on enable_gcp_batch) so the ansible-pull
+# log always shows exactly what the metadata server returns for these attributes, even
+# when a value already arrived via extra-vars. The set_fact steps still only fill an
+# empty value, so an explicit extra-var/CLI value keeps precedence.
+- name: Probe the gcp-network instance metadata attribute
   ansible.builtin.uri:
     url: http://metadata.google.internal/computeMetadata/v1/instance/attributes/gcp-network
     headers:
@@ -384,9 +389,27 @@
     timeout: 5
   register: gcp_network_meta
   failed_when: false
-  when:
-    - enable_gcp_batch | default(false) | bool
-    - gcp_batch_network | default('') | length == 0
+  when: enable_gcp_batch | default(false) | bool
+
+- name: Probe the gcp-subnet instance metadata attribute
+  ansible.builtin.uri:
+    url: http://metadata.google.internal/computeMetadata/v1/instance/attributes/gcp-subnet
+    headers:
+      Metadata-Flavor: Google
+    return_content: true
+    timeout: 5
+  register: gcp_subnet_meta
+  failed_when: false
+  when: enable_gcp_batch | default(false) | bool
+
+- name: "DEBUG: Batch network/subnet metadata lookup"
+  ansible.builtin.debug:
+    msg:
+      - "incoming gcp_batch_network (extra-vars/default): '{{ gcp_batch_network | default('') }}'"
+      - "incoming gcp_batch_subnet  (extra-vars/default): '{{ gcp_batch_subnet | default('') }}'"
+      - "metadata gcp-network -> status={{ gcp_network_meta.status | default('n/a') }} content='{{ gcp_network_meta.content | default('') | trim }}'"
+      - "metadata gcp-subnet  -> status={{ gcp_subnet_meta.status | default('n/a') }} content='{{ gcp_subnet_meta.content | default('') | trim }}'"
+  when: enable_gcp_batch | default(false) | bool
 
 - name: Set gcp_batch_network from the instance metadata
   set_fact:
@@ -397,19 +420,6 @@
     - gcp_network_meta.status | default(0) == 200
     - (gcp_network_meta.content | default('') | trim) | length > 0
 
-- name: Detect the Batch subnet from the instance metadata
-  ansible.builtin.uri:
-    url: http://metadata.google.internal/computeMetadata/v1/instance/attributes/gcp-subnet
-    headers:
-      Metadata-Flavor: Google
-    return_content: true
-    timeout: 5
-  register: gcp_subnet_meta
-  failed_when: false
-  when:
-    - enable_gcp_batch | default(false) | bool
-    - gcp_batch_subnet | default('') | length == 0
-
 - name: Set gcp_batch_subnet from the instance metadata
   set_fact:
     gcp_batch_subnet: "{{ gcp_subnet_meta.content | default('') | trim }}"
@@ -419,12 +429,12 @@
     - gcp_subnet_meta.status | default(0) == 200
     - (gcp_subnet_meta.content | default('') | trim) | length > 0
 
-- name: Report the resolved Batch network/subnet
+- name: "DEBUG: resolved Batch network/subnet (empty = values-file default is used)"
   ansible.builtin.debug:
     msg: >-
-      GCP Batch network/subnet:
-      {{ gcp_batch_network | default('') | default('(values-file default)', true) }} /
-      {{ gcp_batch_subnet | default('') | default('(values-file default)', true) }}
+      Resolved GCP Batch network/subnet ->
+      network: '{{ gcp_batch_network | default('') | default('(values-file default)', true) }}'
+      subnet: '{{ gcp_batch_subnet | default('') | default('(values-file default)', true) }}'
   when: enable_gcp_batch | default(false) | bool
 
 - name: Helm install Galaxy

--- a/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
+++ b/roles/galaxy_k8s_deployment/tasks/galaxy_application.yml
@@ -370,6 +370,63 @@
     - enable_gcp_batch | default(false) | bool
     - gcp_project_id | default('') | length == 0
 
+# Batch VPC network/subnet. Auto-detect from the VM's own instance metadata (the
+# gcp-network / gcp-subnet attributes Leonardo injects) unless set explicitly. Reading
+# it here in the role (not just bin/user_data.sh) means it works regardless of the
+# bootstrap/startup script that launched the VM. Absent -> left empty so the value in
+# the Helm values files is used unchanged.
+- name: Detect the Batch network from the instance metadata
+  ansible.builtin.uri:
+    url: http://metadata.google.internal/computeMetadata/v1/instance/attributes/gcp-network
+    headers:
+      Metadata-Flavor: Google
+    return_content: true
+    timeout: 5
+  register: gcp_network_meta
+  failed_when: false
+  when:
+    - enable_gcp_batch | default(false) | bool
+    - gcp_batch_network | default('') | length == 0
+
+- name: Set gcp_batch_network from the instance metadata
+  set_fact:
+    gcp_batch_network: "{{ gcp_network_meta.content | default('') | trim }}"
+  when:
+    - enable_gcp_batch | default(false) | bool
+    - gcp_batch_network | default('') | length == 0
+    - gcp_network_meta.status | default(0) == 200
+    - (gcp_network_meta.content | default('') | trim) | length > 0
+
+- name: Detect the Batch subnet from the instance metadata
+  ansible.builtin.uri:
+    url: http://metadata.google.internal/computeMetadata/v1/instance/attributes/gcp-subnet
+    headers:
+      Metadata-Flavor: Google
+    return_content: true
+    timeout: 5
+  register: gcp_subnet_meta
+  failed_when: false
+  when:
+    - enable_gcp_batch | default(false) | bool
+    - gcp_batch_subnet | default('') | length == 0
+
+- name: Set gcp_batch_subnet from the instance metadata
+  set_fact:
+    gcp_batch_subnet: "{{ gcp_subnet_meta.content | default('') | trim }}"
+  when:
+    - enable_gcp_batch | default(false) | bool
+    - gcp_batch_subnet | default('') | length == 0
+    - gcp_subnet_meta.status | default(0) == 200
+    - (gcp_subnet_meta.content | default('') | trim) | length > 0
+
+- name: Report the resolved Batch network/subnet
+  ansible.builtin.debug:
+    msg: >-
+      GCP Batch network/subnet:
+      {{ gcp_batch_network | default('') | default('(values-file default)', true) }} /
+      {{ gcp_batch_subnet | default('') | default('(values-file default)', true) }}
+  when: enable_gcp_batch | default(false) | bool
+
 - name: Helm install Galaxy
   kubernetes.core.helm:
     name: galaxy


### PR DESCRIPTION
## What

Makes the GCP Batch VPC `network`/`subnet` reliably reach the runner on Terra/Leonardo
launches, and adds logging to diagnose the current `CODE_GCE_RESOURCE_NOT_FOUND` failure
(`networks/default` not found in `terra-quality-…`).

## Changes

- **Auto-detect `gcp_batch_network` / `gcp_batch_subnet` in the role** from the VM's own
  instance metadata (`gcp-network` / `gcp-subnet`), mirroring the existing `gcp_project_id`
  auto-detect. Previously these were read only in `bin/user_data.sh`, so they were missed
  whenever the VM's bootstrap/startup script isn't our `user_data.sh` (the `ansible-pull`
  playbook is always fresh, but the startup script is whatever the orchestrator baked in).
  Explicit `-e` vars still take precedence; absent metadata leaves the values-file default.

- **Log the lookup**: prints the raw metadata `status` + `content` for both attributes and
  the resolved values, so the `ansible-pull` output shows exactly what the metadata server
  returned (200 + value, 404, empty, …).

## Verifying / how to read the log

After redeploy, the `ansible-pull` output (VM serial-console / startup-script log) shows:

```
TASK [DEBUG: Batch network/subnet metadata lookup]
  metadata gcp-network -> status=200 content='<vpc>'
  metadata gcp-subnet  -> status=200 content='<subnet>'
TASK [DEBUG: resolved Batch network/subnet ...]
  network: '<vpc>' subnet: '<subnet>'
```

- `status=200` + value → picked up (works if the VPC is in the job's own project).
- `status=404` → the attribute isn't set under that key on the VM (key-name mismatch).
- resolved value present but job still 404s → Helm-merge issue or a **Shared VPC** in a host
  project (the runner builds `global/networks/{name}` relative to the job project and can't
  reference another project by bare name — that would need a Galaxy runner change).

Requires a redeploy to produce the diagnostic log. `ansible-playbook --syntax-check` passes;
debug templating render-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
